### PR TITLE
fix tooltip

### DIFF
--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -65,3 +65,7 @@ button.red {
 .tooltip:hover .tooltiptext {
   visibility: visible;
 }
+
+.tooltiptextchild {
+  margin: 5px;
+}

--- a/frontend/src/list-default/list-default.html
+++ b/frontend/src/list-default/list-default.html
@@ -1,7 +1,7 @@
 <div ref="itemData" class="tooltip">
   {{displayValue}}
-  <div class="tooltiptext" style="display:flex; width: 100%; justify-content: space-around;">
-    <div v-if="allude" @click.stop="goToDoc(value)">View Document</div>
-    <div @click.stop="copyText(value)">copy &#x1F4CB;</div>
+  <div class="tooltiptext" style="display:flex; width: 100%; justify-content: space-around; align-items: center; min-width: 180px;">
+    <div class="tooltiptextchild" v-if="allude" @click.stop="goToDoc(value)">View Document</div>
+    <div class="tooltiptextchild" @click.stop="copyText(value)">copy &#x1F4CB;</div>
   </div>
 </div>


### PR DESCRIPTION
the css got a bit messed up whenever the value wasn't an objectid but was eligible for `view document` and `copy`. This fixes that.