### PR TITLE
update code property

### DIFF
--- a/backend/actions/Dashboard/index.js
+++ b/backend/actions/Dashboard/index.js
@@ -1,3 +1,4 @@
 'use strict';
 
 exports.getDashboards = require('./getDashboards');
+exports.updateDashboard = require('./updateDashboard');

--- a/backend/actions/Dashboard/updateDashboard.js
+++ b/backend/actions/Dashboard/updateDashboard.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Archetype = require('archetype');
+
+const UpdateDashboardParams = new Archetype({
+    dashboardId: {
+      $type: 'string',
+      $required: true
+    },
+    code: {
+      $type: 'string',
+      $required: true
+    }
+  }).compile('UpdateDashboardParams');
+  
+  module.exports = ({ db }) => async function updateDashboard(params) {
+    const { dashboardId, code } = new UpdateDashboardParams(params);
+  
+    const Dashboard = db.models[`__Studio_Dashboard`];
+ 
+    const doc = await Dashboard.
+      findByIdAndUpdate(dashboardId, { code }, { sanitizeFilter: true, returnDocument: 'after', overwriteImmutable: true });
+    
+    return { doc };
+  };

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,8 +9,12 @@ const dashboardSchema = require('./db/dashboardSchema');
 module.exports = function backend(db) {
   db = db || mongoose.connection;
   
-  db.model('__Studio_Dashboard', dashboardSchema, '__studio_dashboards');
-  
+  const Dashboard = db.model('__Studio_Dashboard', dashboardSchema, '__studio_dashboards');
+  const doc = new Dashboard({
+    name: 'Test',
+    code: 'Test Code'
+  });
+  doc.save().then(res => console.log(res))
   const actions = applySpec(Actions, { db });
   return actions;
 };

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -22,6 +22,9 @@ if (config__isLambda) {
   exports.Dashboard = {
     getDashboards(params) {
       return client.post('', { action: 'Dashboard.getDashboards', ...params }).then(res => res.data);
+    },
+    updateDashboard(params) {
+      return client.post('', { action: 'Dashboard.updateDashboard', ...params}).then(res => res.data);
     }
   }
   exports.Model = {
@@ -55,6 +58,9 @@ if (config__isLambda) {
     getDashboards: function getDashboards(params) {
       return client.get('/Dashboard/getDashboards', params).then(res => res.data);
     },
+    updateDashboard: function updateDashboard(params) {
+      return client.post('/Dashboard/updateDashboard', params).then(res => res.data);
+    }
   }
   exports.Model = {
     createChart: function (params) {

--- a/frontend/src/dashboard-details/dashboard-details.html
+++ b/frontend/src/dashboard-details/dashboard-details.html
@@ -1,6 +1,15 @@
 <div class="dashboard-details">
   <div v-if="dashboard">
-    {{dashboard.name}}
+    <div>{{dashboard.name}}</div>
+    <div>
+      <pre>{{code}}</pre>
+      <button @click="toggleEditor">Edit</button>
+    </div>
+    <div v-show="showEditor">
+      <textarea class="border border-gray-200 p-2 h-[300px] w-full" ref="codeEditor" v-model="payload">{{code}}</textarea>
+      <button @click="updateCode">Submit</button>
+      <button @click="showEditor = false;">Cancel</button>
+    </div>
   </div>
   <div v-if="!dashboard">
     No dashboard with the given id could be found.

--- a/frontend/src/dashboard-details/dashboard-details.js
+++ b/frontend/src/dashboard-details/dashboard-details.js
@@ -3,8 +3,53 @@
 const api = require('../api');
 const template = require('./dashboard-details.html');
 
+const { EditorState } = require('@codemirror/state');
+const { lineNumbers } = require('@codemirror/view')
+const { EditorView, basicSetup } = require('codemirror');
+const { javascript } = require('@codemirror/lang-javascript');
 
 module.exports = app => app.component('dashboard-details', {
   template: template,
-  props: ['dashboard']
+  props: ['dashboard'],
+  data: function() {
+    return {
+      code: '',
+      editor: null,
+      showEditor: false,
+      payload: ''
+    }
+  },
+  methods: {
+    toggleEditor() {
+      this.showEditor = !this.showEditor;
+    },
+    async updateCode() {
+      const { doc } = await api.Dashboard.updateDashboard({ dashboardId: this.dashboard._id, code: this.payload });
+      this.code = doc.code;
+      this.showEditor = false;
+    }
+  },
+  mounted: function() {
+    this.editor = new EditorView({
+      state: EditorState.create({
+        doc: this.dashboard.code.toString(),
+        extensions: [
+          basicSetup,
+          javascript(),
+          // history(),
+          EditorView.updateListener.of((v) => {
+          }),
+          // keymap.of(historyKeymap)
+        ]
+      }),
+      parent: this.$refs.codeEditor
+    });
+    this.code = this.dashboard.code;
+    this.payload = this.code;
+  },
+  beforeDestroy() {
+    if (this.editor) {
+      this.editor.toTextArea();
+    }
+  }
 });

--- a/scripts/stratos.js
+++ b/scripts/stratos.js
@@ -2,9 +2,10 @@
 
 // env MONGODB\_CONNECTION\_STRING="mongodb://localhost:27017/stratos_local" node ./stratos.js
 
-const db = require('../../BirbAI/backend/db'); // user dependent
+const db = require('../../stratos-ai/backend/db'); // user dependent
 const express = require('express');
 const studio = require('../express');
+const dashboardSchema = require('../backend/db/dashboardSchema')
 
 run().catch(err => {
   console.error(err);
@@ -14,7 +15,6 @@ run().catch(err => {
 async function run() {
   const app = express();
   const conn = await db();
-
   app.use('/studio', studio('/studio/api', conn));
 
   await app.listen(3002);


### PR DESCRIPTION
I strongly feel that codemirror 6 does absolutely nothing for us that codemirror 5 doesn't already do. This new state management system they implemented is so convoluted as well as so pointless that I can't see a good reason to keep trying. Something that was so simple as just doing `CM.getValue()` now requires hoops to jump through and then the hoops specified are not even correct. The documentation states that to get the current value of the text area you need to do `this.editor.state.doc.toString()` but this doesn't actually get the current value. Instead, you have to create an entirely new state and then update the variable `this.editor` with the new state. You must do this each time the text area changes. Am I'm not even sure if this is correct because it is not clear at all in the documentation that is the case. Any attempts to get the current value `this.editor.state.doc` just returned the old value in the text area, not what was newly typed in. I rest my case.  