### PR TITLE
display node env in navbar

### DIFF
--- a/backend/actions/index.js
+++ b/backend/actions/index.js
@@ -3,3 +3,4 @@
 exports.Dashboard = require('./Dashboard');
 exports.Model = require('./Model');
 exports.Script = require('./Script');
+exports.status = require('./status');

--- a/backend/actions/status.js
+++ b/backend/actions/status.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const nodeEnv = process.env.NODE_ENV;
+
+module.exports = () => async function status() {
+  return { nodeEnv };
+};

--- a/express.js
+++ b/express.js
@@ -3,7 +3,7 @@
 const Backend = require('./backend');
 const express = require('express');
 const frontend = require('./frontend');
-const { toRoute } = require('extrovert');
+const { toRoute, objectRouter } = require('extrovert');
 
 module.exports = function(apiUrl, conn, options) {
   const router = express.Router();
@@ -11,22 +11,7 @@ module.exports = function(apiUrl, conn, options) {
   apiUrl = apiUrl || '/admin/api';
   const backend = Backend(conn);
 
-  const apiRouter = express.Router();
-  apiRouter.use(express.json());
-  for (const [name, actions] of Object.entries(backend)) {
-    const subrouter = express.Router();
-    for (const [actionName, action] of Object.entries(actions)) {
-      subrouter.options(`/${actionName}`, (req, res) => res.send(''));
-      subrouter.get(`/${actionName}`, toRoute(action));
-      subrouter.put(`/${actionName}`, toRoute(action));
-      subrouter.post(`/${actionName}`, toRoute(action));
-      subrouter.delete(`/${actionName}`, toRoute(action));
-    }
-
-    apiRouter.use(`/${name}`, subrouter);
-  }
-
-  router.use('/api', apiRouter);
+  router.use('/api', express.json(), objectRouter(backend, toRoute));
 
   frontend(apiUrl, false, options);
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -13,7 +13,7 @@ if (typeof config__setAuthorizationHeaderFrom === 'string' && config__setAuthori
     if (accessToken) {
       req.headers.authorization = accessToken;
     }
-  
+
     return req;
   });
 }
@@ -29,6 +29,9 @@ client.interceptors.response.use(
 );
 
 if (config__isLambda) {
+  exports.status = function status() {
+    return client.get('', { action: 'status' }).then(res => res.data);
+  };
   exports.Dashboard = {
     createDashboard(params) {
       return client.post('', { action: 'Dashboard.createDashboard', ...params }).then(res => res.data);
@@ -70,6 +73,9 @@ if (config__isLambda) {
     }
   };
 } else {
+  exports.status = function status() {
+    return client.get('/status').then(res => res.data);
+  };
   exports.Dashboard = {
     createDashboard: function createDashboard(params) {
       return client.post('/Dashboard/createDashboard', params).then(res => res.data);

--- a/frontend/src/navbar/navbar.html
+++ b/frontend/src/navbar/navbar.html
@@ -1,8 +1,11 @@
 <div class="navbar">
-  <div class="nav-left">
+  <div class="nav-left flex items-center gap-4 h-full">
     <router-link to="/">
       <img src="images/logo.svg" alt="Mongoose Studio Logo" />
     </router-link>
+    <div v-if="!!nodeEnv" class="inline-flex items-center rounded-md px-2 py-1 text-sm font-medium text-gray-900" :class="warnEnv ? 'bg-red-300' : 'bg-yellow-300'">
+      {{nodeEnv}}
+    </div>
   </div>
   <div class="nav-right h-full">
     <div class="sm:ml-6 sm:flex sm:space-x-8 h-full">

--- a/frontend/src/navbar/navbar.js
+++ b/frontend/src/navbar/navbar.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const api = require('../api');
 const template = require('./navbar.html');
 
 const appendCSS = require('../appendCSS');
@@ -8,9 +9,18 @@ appendCSS(require('./navbar.css'));
 
 module.exports = app => app.component('navbar', {
   template: template,
+  data: () => ({ nodeEnv: null }),
   computed: {
     routeName() {
       return this.$route.name;
+    },
+    warnEnv() {
+      return this.nodeEnv === 'prod' || this.nodeEnv === 'production';
     }
+  },
+  async mounted() {
+    const { nodeEnv } = await api.status();
+    console.log('AG', nodeEnv);
+    this.nodeEnv = nodeEnv;
   }
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "archetype": "0.13.1",
     "csv-stringify": "6.3.0",
     "ejson": "^2.2.3",
-    "extrovert": "0.0.24",
+    "extrovert": "0.0.25",
     "node-inspect-extracted": "3.x",
     "tailwindcss": "3.4.0",
     "vanillatoasts": "^1.6.0",


### PR DESCRIPTION
Good suggestion: display nodeEnv in navbar (red for "prod" or "production") to help prevent accidentally deleting a bunch of data in prod because you didn't know you were in prod.

![image](https://github.com/user-attachments/assets/c7833637-f96a-48c8-9b53-63862480659d)
