### PR TITLE
Add auto-expanding chat textarea

### DIFF
--- a/frontend/src/chat/chat.html
+++ b/frontend/src/chat/chat.html
@@ -58,7 +58,7 @@
 
     <!-- Input Area -->
     <div class="border-t p-4">
-      <form @submit.prevent="sendMessage" :disabled="sendingMessage" class="flex gap-2">
+      <form @submit.prevent="sendMessage" :disabled="sendingMessage" class="flex gap-2 items-end justify-end">
         <textarea
           v-model="newMessage"
           placeholder="Ask something..."
@@ -68,7 +68,7 @@
           @input="adjustTextareaHeight"
           @keydown.enter.exact.prevent="handleEnter"
         ></textarea>
-        <button class="bg-blue-600 text-white px-4 py-2 rounded disabled:bg-gray-600" :disabled="sendingMessage">
+        <button class="bg-blue-600 text-white px-4 h-[42px] rounded disabled:bg-gray-600" :disabled="sendingMessage">
           <svg v-if="sendingMessage" style="height: 1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <g>
               <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" opacity="0.3" />

--- a/frontend/src/chat/chat.html
+++ b/frontend/src/chat/chat.html
@@ -59,11 +59,15 @@
     <!-- Input Area -->
     <div class="border-t p-4">
       <form @submit.prevent="sendMessage" :disabled="sendingMessage" class="flex gap-2">
-        <input
+        <textarea
           v-model="newMessage"
           placeholder="Ask something..."
-          class="flex-1 border rounded px-4 py-2"
-        />
+          class="flex-1 border rounded px-4 py-2 resize-none overflow-y-auto"
+          rows="1"
+          ref="messageInput"
+          @input="adjustTextareaHeight"
+          @keydown.enter.exact.prevent="handleEnter"
+        ></textarea>
         <button class="bg-blue-600 text-white px-4 py-2 rounded disabled:bg-gray-600" :disabled="sendingMessage">
           <svg v-if="sendingMessage" style="height: 1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <g>

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -44,6 +44,11 @@ module.exports = app => app.component('chat', {
         this.chatMessages.push(chatMessages[1]);
 
         this.newMessage = '';
+        this.$nextTick(() => {
+          if (this.$refs.messageInput) {
+            this.$refs.messageInput.style.height = 'auto';
+          }
+        });
 
         this.$nextTick(() => {
           if (this.$refs.messagesContainer) {
@@ -53,6 +58,18 @@ module.exports = app => app.component('chat', {
       } finally {
         this.sendingMessage = false;
       }
+    },
+    handleEnter(ev) {
+      if (!ev.shiftKey) {
+        this.sendMessage();
+      }
+    },
+    adjustTextareaHeight(ev) {
+      const textarea = ev.target;
+      textarea.style.height = 'auto';
+      const lineHeight = parseInt(window.getComputedStyle(textarea).lineHeight, 10);
+      const maxHeight = lineHeight * 5;
+      textarea.style.height = Math.min(textarea.scrollHeight, maxHeight) + 'px';
     },
     selectThread(threadId) {
       this.$router.push('/chat/' + threadId);


### PR DESCRIPTION
## Summary
- replace chat input with a textarea
- auto-resize textarea up to five lines
- reset textarea height after sending
- allow Enter to send message when Shift is not held

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866dd96e6888324b8ee70495325086d