### PR TITLE
Fix dashboard result rendering

### DIFF
--- a/frontend/src/dashboard-result/dashboard-result.html
+++ b/frontend/src/dashboard-result/dashboard-result.html
@@ -1,10 +1,10 @@
 <div>
   <div v-if="Array.isArray(result)">
-    <div v-for="el in result">
+    <div v-for="el in result" :key="el._id || el.finishedEvaluatingAt">
       <component
         class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl"
-        :is="getComponentForValue(res)"
-        :value="res">
+        :is="getComponentForValue(el)"
+        :value="el">
       </component>
     </div>
   </div>

--- a/frontend/src/dashboard/dashboard.html
+++ b/frontend/src/dashboard/dashboard.html
@@ -40,7 +40,11 @@
         </div>
       </div>
       <div v-else>
-        <dashboard-result :result="dashboardResult.result" :finishedEvaluatingAt="dashboardResult.finishedEvaluatingAt"></dashboard-result>
+        <dashboard-result
+          :key="dashboardResult.finishedEvaluatingAt"
+          :result="dashboardResult.result"
+          :finishedEvaluatingAt="dashboardResult.finishedEvaluatingAt">
+        </dashboard-result>
       </div>
     </div>
     <div v-if="showEditor" class="mt-4">


### PR DESCRIPTION
## Summary
- ensure dashboard result component is remounted after evaluation
- fix array rendering in dashboard-result component

## Testing
- `npm test` *(fails: Timeout of 2000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6882a0b48cb48324b1a41eec9706ff19