### PR TITLE
Fix chat bottom offset

### DIFF
--- a/frontend/src/chat/chat.html
+++ b/frontend/src/chat/chat.html
@@ -1,4 +1,4 @@
-<div class="flex" style="height: calc(100vh - 55px)">
+<div class="flex" style="height: calc(100vh - 55px); height: calc(100dvh - 55px)">
   <div class="fixed top-[65px] cursor-pointer bg-gray-100 rounded-r-md z-10" @click="hideSidebar = false">
     <svg xmlns="http://www.w3.org/2000/svg" style="h-5 w-5" viewBox="0 -960 960 960" class="w-5" fill="#5f6368"><path d="M360-120v-720h80v720h-80Zm160-160v-400l200 200-200 200Z"/></svg>
   </div>


### PR DESCRIPTION
## Summary
- tweak chat container height to use 100dvh so the message input isn't hidden by mobile browser chrome

## Testing
- `npm test` *(fails: Timeout of 2000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6882a12b845483248d1d35998388066d