### PR TITLE
feat: make chat model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you have a Mongoose Studio Pro API key, you can set it as follows:
 
 ```javascript
 const opts = process.env.MONGOOSE_STUDIO_API_KEY ? { apiKey: process.env.MONGOOSE_STUDIO_API_KEY } : {};
+// Optionally specify which ChatGPT model to use for chat messages
+opts.model = 'gpt-4o-mini';
 
 // Mount Mongoose Studio on '/studio'
 app.use('/studio', await studio('/studio/api', mongoose, opts));
@@ -48,7 +50,9 @@ const { execSync } = require('child_process');
 
 // Sign up for Mongoose Studio Pro to get an API key, or omit `apiKey` for local dev.
 const opts = {
-  apiKey: process.env.MONGOOSE_STUDIO_API_KEY
+  apiKey: process.env.MONGOOSE_STUDIO_API_KEY,
+  // Optionally specify which ChatGPT model to use for chat messages
+  model: 'gpt-4o-mini'
 };
 console.log('Creating Mongoose studio', opts);
 require('@mongoosejs/studio/frontend')(`/.netlify/functions/studio`, true, opts).then(() => {
@@ -65,7 +69,8 @@ require('@mongoosejs/studio/frontend')(`/.netlify/functions/studio`, true, opts)
 const mongoose = require('mongoose');
 
 const handler = require('@mongoosejs/studio/backend/netlify')({
-  apiKey: process.env.MONGOOSE_STUDIO_API_KEY
+  apiKey: process.env.MONGOOSE_STUDIO_API_KEY,
+  model: 'gpt-4o-mini'
 }).handler;
 
 let conn = null;

--- a/backend/actions/ChatThread/createChatMessage.js
+++ b/backend/actions/ChatThread/createChatMessage.js
@@ -70,7 +70,7 @@ module.exports = ({ db, studioConnection, options }) => async function createCha
       script,
       executionResult: null
     }),
-    createChatMessageCore(llmMessages, getModelDescriptions(db), authorization).then(res => {
+    createChatMessageCore(llmMessages, getModelDescriptions(db), options?.model, authorization).then(res => {
       const content = res.response;
       return ChatMessage.create({
         chatThreadId,
@@ -106,7 +106,7 @@ async function summarizeChatThread(messages, authorization) {
   return await response.json();
 }
 
-async function createChatMessageCore(messages, modelDescriptions, authorization) {
+async function createChatMessageCore(messages, modelDescriptions, model, authorization) {
   const headers = { 'Content-Type': 'application/json' };
   if (authorization) {
     headers.Authorization = authorization;
@@ -116,7 +116,8 @@ async function createChatMessageCore(messages, modelDescriptions, authorization)
     headers,
     body: JSON.stringify({
       messages,
-      modelDescriptions
+      modelDescriptions,
+      model
     })
   }).then(response => {
     if (response.status < 200 || response.status >= 400) {


### PR DESCRIPTION
## Summary
- allow passing `model` option when instantiating Mongoose Studio
- forward `model` to chat completion API
- document model option in README examples

## Testing
- `npm test` *(fails: Timeout of 2000ms exceeded; likely missing MongoDB server)*

------
https://chatgpt.com/codex/tasks/task_e_68950bd261b4832499e6486c507600c7