### PR TITLE
fix: include auth header for chat thread title

### DIFF
--- a/backend/actions/ChatThread/createChatMessage.js
+++ b/backend/actions/ChatThread/createChatMessage.js
@@ -46,12 +46,13 @@ module.exports = ({ db, studioConnection, options }) => async function createCha
   }));
   llmMessages.push({ role: 'user', content });
 
+  let summarizePromise = Promise.resolve();
   if (chatThread.title == null) {
-    summarizeChatThread(llmMessages, authorization).then(res => {
+    summarizePromise = summarizeChatThread(llmMessages, authorization).then(res => {
       const title = res.response;
       chatThread.title = title;
       return chatThread.save();
-    }).catch(() => {});
+    });
   }
 
   if (options.context) {
@@ -82,6 +83,7 @@ module.exports = ({ db, studioConnection, options }) => async function createCha
     })
   ]);
 
+  await summarizePromise;
   return { chatMessages, chatThread };
 };
 

--- a/backend/actions/ChatThread/createChatMessage.js
+++ b/backend/actions/ChatThread/createChatMessage.js
@@ -47,7 +47,7 @@ module.exports = ({ db, studioConnection, options }) => async function createCha
   llmMessages.push({ role: 'user', content });
 
   if (chatThread.title == null) {
-    summarizeChatThread(llmMessages).then(res => {
+    summarizeChatThread(llmMessages, authorization).then(res => {
       const title = res.response;
       chatThread.title = title;
       return chatThread.save();

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -37,11 +37,16 @@ module.exports = app => app.component('chat', {
           }
         });
 
-        const { chatMessages } = await api.ChatThread.createChatMessage({
+        const { chatMessages, chatThread } = await api.ChatThread.createChatMessage({
           chatThreadId: this.chatThreadId,
           content: this.newMessage
         });
         this.chatMessages.push(chatMessages[1]);
+        for (const thread of this.chatThreads) {
+          if (thread._id === chatThread._id) {
+            thread.title = chatThread.title;
+          }
+        }
 
         this.newMessage = '';
         this.$nextTick(() => {


### PR DESCRIPTION
## Summary
- pass auth info to chat title summarization so titles are generated correctly

## Testing
- `npm test` (fails: Timeout of 2000ms exceeded in "before all" hook)


------
https://chatgpt.com/codex/tasks/task_e_6899f6bc96b08324baa3e8d69d1b7bbf