### PR TITLE
feat: expand dashboard result via modal

### DIFF
--- a/frontend/src/dashboard/dashboard.html
+++ b/frontend/src/dashboard/dashboard.html
@@ -43,7 +43,8 @@
         <div class="relative">
           <button
             class="absolute top-2 right-2 px-2 py-1 text-xs bg-blue-500 text-white border-none rounded cursor-pointer hover:bg-blue-600 transition-colors flex items-center"
-            @click="openDetailModal">
+            @click="openDetailModal"
+            aria-label="Expand dashboard result">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 1v4m0 0h-4m4 0l-5-5" />
             </svg>

--- a/frontend/src/dashboard/dashboard.html
+++ b/frontend/src/dashboard/dashboard.html
@@ -40,11 +40,20 @@
         </div>
       </div>
       <div v-else>
-        <dashboard-result
-          :key="dashboardResult.finishedEvaluatingAt"
-          :result="dashboardResult.result"
-          :finishedEvaluatingAt="dashboardResult.finishedEvaluatingAt">
-        </dashboard-result>
+        <div class="relative">
+          <button
+            class="absolute top-2 right-2 px-2 py-1 text-xs bg-blue-500 text-white border-none rounded cursor-pointer hover:bg-blue-600 transition-colors flex items-center"
+            @click="openDetailModal">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 1v4m0 0h-4m4 0l-5-5" />
+            </svg>
+          </button>
+          <dashboard-result
+            :key="dashboardResult.finishedEvaluatingAt"
+            :result="dashboardResult.result"
+            :finishedEvaluatingAt="dashboardResult.finishedEvaluatingAt">
+          </dashboard-result>
+        </div>
       </div>
     </div>
     <div v-if="showEditor" class="mt-4">
@@ -74,3 +83,16 @@
     No dashboard with the given id could be found.
   </div>
 </div>
+
+<modal v-if="showDetailModal" containerClass="!h-[90vh] !w-[90vw]">
+  <template #body>
+    <div class="absolute font-mono right-1 top-1 cursor-pointer text-xl" @click="showDetailModal = false;">&times;</div>
+    <div class="h-full overflow-auto">
+      <dashboard-result
+        v-if="dashboardResult"
+        :result="dashboardResult.result"
+        :finishedEvaluatingAt="dashboardResult.finishedEvaluatingAt">
+      </dashboard-result>
+    </div>
+  </template>
+</modal>

--- a/frontend/src/dashboard/dashboard.html
+++ b/frontend/src/dashboard/dashboard.html
@@ -85,7 +85,13 @@
   </div>
 </div>
 
-<modal v-if="showDetailModal" containerClass="!h-[90vh] !w-[90vw]">
+<modal
+  v-if="showDetailModal"
+  containerClass="!h-[90vh] !w-[90vw]"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Dashboard Details"
+>
   <template #body>
     <div class="absolute font-mono right-1 top-1 cursor-pointer text-xl" @click="showDetailModal = false;" role="button" aria-label="Close modal">&times;</div>
     <div class="h-full overflow-auto">

--- a/frontend/src/dashboard/dashboard.html
+++ b/frontend/src/dashboard/dashboard.html
@@ -86,7 +86,7 @@
 
 <modal v-if="showDetailModal" containerClass="!h-[90vh] !w-[90vw]">
   <template #body>
-    <div class="absolute font-mono right-1 top-1 cursor-pointer text-xl" @click="showDetailModal = false;">&times;</div>
+    <div class="absolute font-mono right-1 top-1 cursor-pointer text-xl" @click="showDetailModal = false;" role="button" aria-label="Close modal">&times;</div>
     <div class="h-full overflow-auto">
       <dashboard-result
         v-if="dashboardResult"

--- a/frontend/src/dashboard/dashboard.js
+++ b/frontend/src/dashboard/dashboard.js
@@ -15,7 +15,8 @@ module.exports = app => app.component('dashboard', {
       showEditor: false,
       dashboard: null,
       dashboardResults: [],
-      errorMessage: null
+      errorMessage: null,
+      showDetailModal: false
     };
   },
   methods: {
@@ -47,6 +48,9 @@ module.exports = app => app.component('dashboard', {
       } finally {
         this.status = 'loaded';
       }
+    },
+    openDetailModal() {
+      this.showDetailModal = true;
     }
   },
   computed: {


### PR DESCRIPTION
## Summary
- allow opening the latest dashboard result in a full-screen modal
- add state and method to handle dashboard result modal

## Testing
- `npm test` (fails: Timeout of 2000ms exceeded)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893d8b7e460832489b55a8a0ff451fe