### PR TITLE
feat: add copy button to chat message

### DIFF
--- a/frontend/src/chat/chat-message/chat-message.html
+++ b/frontend/src/chat/chat-message/chat-message.html
@@ -3,7 +3,15 @@
     class="min-w-0 max-w-[calc(100vw-4rem)] lg:max-w-[calc(100vw-20rem)]"
     :class="{'text-right': message.role === 'user'}">
 
-    <div class="text-sm text-gray-900 md:p-3 rounded-md inline-block" :class="styleForMessage">
+    <div class="text-sm text-gray-900 md:p-3 rounded-md inline-block relative" :class="styleForMessage">
+      <button
+        v-if="message.role !== 'user'"
+        class="absolute top-1 right-1 text-gray-400 hover:text-gray-600"
+        @click="copyMessage">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+        </svg>
+      </button>
       <div v-for="part in contentSplitByScripts">
         <div v-if="part.type === 'text'" v-html="marked(part.content)">
         </div>

--- a/frontend/src/chat/chat-message/chat-message.js
+++ b/frontend/src/chat/chat-message/chat-message.js
@@ -2,6 +2,7 @@
 
 const api = require('../../api');
 const marked = require('marked').marked;
+const vanillatoasts = require('vanillatoasts');
 const template = require('./chat-message.html');
 
 module.exports = app => app.component('chat-message', {
@@ -61,6 +62,31 @@ module.exports = app => app.component('chat-message', {
       });
       message.executionResult = chatMessage.executionResult;
       console.log(message);
+    },
+    async copyMessage() {
+      const parts = this.contentSplitByScripts;
+      let output = '';
+      for (const part of parts) {
+        if (part.type === 'text') {
+          output += part.content + '\n';
+        } else if (part.type === 'code') {
+          let result = this.message.executionResult?.output;
+          if (result != null && typeof result === 'object') {
+            result = JSON.stringify(result, null, 2);
+          }
+          if (result) {
+            output += result + '\n';
+          }
+        }
+      }
+      await navigator.clipboard.writeText(output.trim());
+      vanillatoasts.create({
+        title: 'Message output copied!',
+        type: 'success',
+        timeout: 3000,
+        icon: 'images/success.png',
+        positionClass: 'bottomRight'
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary
- add vanillatoast-backed copy button on chat messages
- copy message text and executed code output without raw code blocks

## Testing
- `npm test` (fails: Timeout of 2000ms exceeded)

------
https://chatgpt.com/codex/tasks/task_e_68a4a27413d883248768cf33c37bf033