### PR TITLE
feat: add dashboards loading spinner

### DIFF
--- a/frontend/src/dashboards/dashboards.html
+++ b/frontend/src/dashboards/dashboards.html
@@ -1,97 +1,120 @@
 <div class="dashboards max-w-5xl mx-auto mt-8">
-  <div v-if="status === 'loaded' && dashboards.length === 0">
-    <div class="text-center">
-      <h3 class="mt-2 text-sm font-semibold text-gray-900">No dashboards yet</h3>
-      <p class="mt-1 text-sm text-gray-500">Get started by creating a new dashboard.</p>
-      <div class="mt-6">
-        <button type="button" class="inline-flex items-center rounded-md bg-teal-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600">
-          <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
-          </svg>
-          New Dashboard
-        </button>
-      </div>
-    </div>
+  <div v-if="status === 'loading'" class="text-center mt-4">
+    <svg
+      class="inline w-8 h-8 animate-spin text-ultramarine-600"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        class="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        stroke-width="4"
+      ></circle>
+      <path
+        class="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
   </div>
-
-
-  <div class="px-4 sm:px-6 lg:px-8">
-    <div class="sm:flex sm:items-center">
-      <div class="sm:flex-auto">
-        <h1 class="text-base font-semibold leading-6 text-gray-900">Dashboards</h1>
-      </div>
-      <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-        <button
-          type="button"
-          @click="showCreateDashboardModal = true"
-          class="block rounded-md bg-teal-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-teal-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600">Create New Dashboard</button>
-      </div>
-    </div>
-    <div class="mt-8 flow-root">
-      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-        <div class="inline-block min-w-full py-2 align-middle">
-          <table class="min-w-full divide-y divide-gray-300">
-            <thead>
-              <tr>
-                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 lg:pl-8">Title</th>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 w-[50%]">Description</th>
-                <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 lg:pr-8">
-                </th>
-                <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 lg:pr-8">
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 bg-white">
-              <tr v-for="dashboard in dashboards">
-                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">{{dashboard.title}}</td>
-                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 truncate w-[50%]">{{dashboard.description}}</td>
-                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
-                  <router-link
-                    :to="'/dashboard/' + dashboard._id + '?edit=true'"
-                    class="text-teal-600 hover:text-teal-900">
-                    Edit
-                  </router-link>
-                </td>
-                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
-                  <router-link
-                    :to="'/dashboard/' + dashboard._id"
-                    class="text-teal-600 hover:text-teal-900">
-                    View
-                  </router-link>
-                </td>
-                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
-                  <button
-                    @click="showDeleteDashboardModal=dashboard"
-                    class="text-teal-600 hover:text-teal-900">
-                    Delete
-                  </button>
-                </td>
-              </tr>
-  
-              <!-- More people... -->
-            </tbody>
-          </table>
+  <div v-else>
+    <div v-if="dashboards.length === 0">
+      <div class="text-center">
+        <h3 class="mt-2 text-sm font-semibold text-gray-900">No dashboards yet</h3>
+        <p class="mt-1 text-sm text-gray-500">Get started by creating a new dashboard.</p>
+        <div class="mt-6">
+          <button type="button" class="inline-flex items-center rounded-md bg-ultramarine-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-ultramarine-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ultramarine-600">
+            <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
+            </svg>
+            New Dashboard
+          </button>
         </div>
       </div>
     </div>
-  </div>
 
-  <modal v-if="showCreateDashboardModal">
-    <template v-slot:body>
-      <div class="modal-exit" @click="showCreateDashboardModal = false;">&times;</div>
-      
-      <create-dashboard @close="insertNewDashboard"></create-dashboard>
-    </template>
-  </modal>
-
-  <modal v-if="showDeleteDashboardModal">
-    <template v-slot:body>
-      <div class="modal-exit" @click="showDeleteDashboardModal = null;">&times;</div>
-      <h2>Are you sure you want to delete this dashboard titled {{showDeleteDashboardModal.title}}?</h2>
-      <div class="flex space-x-2">
-        <button class="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500" @click="deleteDashboard(showDeleteDashboardModal)">Yes, delete</button>
-        <button class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-600" @click="showDeleteDashboardModal=null;">Cancel</button>
+    <div class="px-4 sm:px-6 lg:px-8">
+      <div class="sm:flex sm:items-center">
+        <div class="sm:flex-auto">
+          <h1 class="text-base font-semibold leading-6 text-gray-900">Dashboards</h1>
+        </div>
+        <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+          <button
+            type="button"
+            @click="showCreateDashboardModal = true"
+            class="block rounded-md bg-ultramarine-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-ultramarine-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ultramarine-600">Create New Dashboard</button>
+        </div>
       </div>
-    </template>
-  </modal>
+      <div class="mt-8 flow-root">
+        <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div class="inline-block min-w-full py-2 align-middle">
+            <table class="min-w-full divide-y divide-gray-300">
+              <thead>
+                <tr>
+                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 lg:pl-8">Title</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 w-[50%]">Description</th>
+                  <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 lg:pr-8">
+                  </th>
+                  <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 lg:pr-8">
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white">
+                <tr v-for="dashboard in dashboards">
+                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">{{dashboard.title}}</td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 truncate w-[50%]">{{dashboard.description}}</td>
+                  <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
+                    <router-link
+                      :to="'/dashboard/' + dashboard._id + '?edit=true'"
+                      class="text-ultramarine-600 hover:text-ultramarine-900">
+                      Edit
+                    </router-link>
+                  </td>
+                  <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
+                    <router-link
+                      :to="'/dashboard/' + dashboard._id"
+                      class="text-ultramarine-600 hover:text-ultramarine-900">
+                      View
+                    </router-link>
+                  </td>
+                  <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
+                    <button
+                      @click="showDeleteDashboardModal=dashboard"
+                      class="text-ultramarine-600 hover:text-ultramarine-900">
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+
+                <!-- More people... -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <modal v-if="showCreateDashboardModal">
+      <template v-slot:body>
+        <div class="modal-exit" @click="showCreateDashboardModal = false;">&times;</div>
+
+        <create-dashboard @close="insertNewDashboard"></create-dashboard>
+      </template>
+    </modal>
+
+    <modal v-if="showDeleteDashboardModal">
+      <template v-slot:body>
+        <div class="modal-exit" @click="showDeleteDashboardModal = null;">&times;</div>
+        <h2>Are you sure you want to delete this dashboard titled {{showDeleteDashboardModal.title}}?</h2>
+        <div class="flex space-x-2">
+          <button class="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500" @click="deleteDashboard(showDeleteDashboardModal)">Yes, delete</button>
+          <button class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-600" @click="showDeleteDashboardModal=null;">Cancel</button>
+        </div>
+      </template>
+    </modal>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- show a spinner while dashboards load
- replace teal styling with ultramarine accents

## Testing
- `npm test` (fails: Timeout of 2000ms exceeded)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2b7817008324b50fe4043c816818