### PR TITLE
Handle dashboard evaluation errors

### DIFF
--- a/backend/actions/Dashboard/getDashboard.js
+++ b/backend/actions/Dashboard/getDashboard.js
@@ -41,14 +41,23 @@ module.exports = ({ db }) => async function getDashboard(params) {
       return { dashboard, error: { message: error.message } };
     }
 
-    const { dashboardResult } = await startExec.then(({ dashboardResult }) => {
-      if (!dashboardResult) {
-        return;
-      }
-      return completeDashboardEvaluate(dashboardResult._id, $workspaceId, authorization, result);
-    });
+    try {
+      const { dashboardResult } = await startExec.then(({ dashboardResult }) => {
+        if (!dashboardResult) {
+          return {};
+        }
+        return completeDashboardEvaluate(
+          dashboardResult._id,
+          $workspaceId,
+          authorization,
+          result
+        );
+      });
 
-    return { dashboard, dashboardResult };
+      return { dashboard, dashboardResult };
+    } catch (error) {
+      return { dashboard, error: { message: error.message } };
+    }
   } else {
     const { dashboardResults } = await getDashboardResults(dashboardId, $workspaceId, authorization);
     return { dashboard, dashboardResults };

--- a/test/Dashboard.getDashboard.error.test.js
+++ b/test/Dashboard.getDashboard.error.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert');
+const { actions, connection } = require('./setup.test');
+const dashboardSchema = require('../backend/db/dashboardSchema');
+
+// Define the dashboard model on the main connection
+const Dashboard = connection.model('__Studio_Dashboard', dashboardSchema, 'studio__dashboards');
+
+describe('Dashboard.getDashboard() error handling', function () {
+  afterEach(async function () {
+    await Dashboard.deleteMany();
+  });
+
+  it('handles errors from startDashboardEvaluate', async function () {
+    const doc = await Dashboard.create({ title: 'Test', code: 'return 42;' });
+
+    const originalFetch = global.fetch;
+    global.fetch = () => Promise.reject(new Error('start error'));
+
+    const res = await actions.Dashboard.getDashboard({
+      dashboardId: doc._id.toString(),
+      evaluate: true,
+      roles: ['dashboards']
+    });
+
+    global.fetch = originalFetch;
+
+    assert.ok(res.dashboard);
+    assert.deepStrictEqual(res.error, { message: 'start error' });
+  });
+});

--- a/test/Dashboard.getDashboard.error.test.js
+++ b/test/Dashboard.getDashboard.error.test.js
@@ -13,21 +13,15 @@ describe('Dashboard.getDashboard() error handling', function () {
   });
 
   it('handles errors from startDashboardEvaluate', async function () {
-    const doc = await Dashboard.create({ title: 'Test', code: 'return 42;' });
+    const doc = await Dashboard.create({ title: 'Test', code: 'throw new Error("test error")' });
 
-    const originalFetch = global.fetch;
-    global.fetch = () => Promise.reject(new Error('start error'));
-    try {
-      const res = await actions.Dashboard.getDashboard({
-        dashboardId: doc._id.toString(),
-        evaluate: true,
-        roles: ['dashboards']
-      });
+    const res = await actions.Dashboard.getDashboard({
+      dashboardId: doc._id.toString(),
+      evaluate: true,
+      roles: ['dashboards']
+    });
 
-      assert.ok(res.dashboard);
-      assert.deepStrictEqual(res.error, { message: 'start error' });
-    } finally {
-      global.fetch = originalFetch;
-    }
+    assert.ok(res.dashboard);
+    assert.deepStrictEqual(res.error, { message: 'test error' });
   });
 });

--- a/test/Dashboard.getDashboard.error.test.js
+++ b/test/Dashboard.getDashboard.error.test.js
@@ -17,16 +17,17 @@ describe('Dashboard.getDashboard() error handling', function () {
 
     const originalFetch = global.fetch;
     global.fetch = () => Promise.reject(new Error('start error'));
+    try {
+      const res = await actions.Dashboard.getDashboard({
+        dashboardId: doc._id.toString(),
+        evaluate: true,
+        roles: ['dashboards']
+      });
 
-    const res = await actions.Dashboard.getDashboard({
-      dashboardId: doc._id.toString(),
-      evaluate: true,
-      roles: ['dashboards']
-    });
-
-    global.fetch = originalFetch;
-
-    assert.ok(res.dashboard);
-    assert.deepStrictEqual(res.error, { message: 'start error' });
+      assert.ok(res.dashboard);
+      assert.deepStrictEqual(res.error, { message: 'start error' });
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Catch and return errors from dashboard evaluation completion in `getDashboard`
- Add test to verify error handling when dashboard evaluation setup fails

## Testing
- `npm run lint`
- `npm test` *(fails: Timeout of 2000ms exceeded in before/after hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68af3a1b321c8324b02eedac89eed0bc