### PR TITLE
fix: expose ObjectId and report dashboard evaluation errors

### DIFF
--- a/backend/db/dashboardSchema.js
+++ b/backend/db/dashboardSchema.js
@@ -18,7 +18,7 @@ const dashboardSchema = new mongoose.Schema({
 });
 
 dashboardSchema.methods.evaluate = async function evaluate() {
-  const context = vm.createContext({ db: this.constructor.db, setTimeout });
+  const context = vm.createContext({ db: this.constructor.db, setTimeout, ObjectId: mongoose.Types.ObjectId });
   let result = null;
   result = await vm.runInContext(formatFunction(this.code), context);
   if (result.$document?.constructor?.modelName) {

--- a/frontend/src/dashboard/dashboard.js
+++ b/frontend/src/dashboard/dashboard.js
@@ -35,16 +35,19 @@ module.exports = app => app.component('dashboard', {
     },
     async evaluateDashboard() {
       this.status = 'evaluating';
+      this.errorMessage = null;
       try {
         const { dashboard, dashboardResult, error } = await api.Dashboard.getDashboard({ dashboardId: this.dashboardId, evaluate: true });
         this.dashboard = dashboard;
-        if (error) {
-          this.errorMessage = error.message;
-        }
         this.code = this.dashboard.code;
         this.title = this.dashboard.title;
         this.description = this.dashboard.description ?? '';
-        this.dashboardResults.unshift(dashboardResult);
+        if (dashboardResult) {
+          this.dashboardResults.unshift(dashboardResult);
+        }
+        if (error) {
+          this.errorMessage = error.message;
+        }
       } finally {
         this.status = 'loaded';
       }

--- a/test/Dashboard.evaluate.objectid.test.js
+++ b/test/Dashboard.evaluate.objectid.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const { connection } = require('./setup.test');
+const dashboardSchema = require('../backend/db/dashboardSchema');
+
+const Dashboard = connection.model('__Studio_Dashboard', dashboardSchema, 'studio__dashboards');
+
+describe('Dashboard.evaluate() ObjectId', function() {
+  afterEach(async function() {
+    await Dashboard.deleteMany();
+  });
+
+  it('exposes ObjectId in sandbox', async function() {
+    const doc = await Dashboard.create({ title: 'test', code: 'return { id: new ObjectId() };' });
+    const res = await doc.evaluate();
+    assert.ok(res.id);
+    assert.strictEqual(res.id.constructor.name, 'ObjectId');
+  });
+});
+

--- a/test/Dashboard.getDashboard.error.test.js
+++ b/test/Dashboard.getDashboard.error.test.js
@@ -23,5 +23,6 @@ describe('Dashboard.getDashboard() error handling', function () {
 
     assert.ok(res.dashboard);
     assert.deepStrictEqual(res.error, { message: 'test error' });
+    assert.strictEqual(res.dashboardResult, undefined);
   });
 });


### PR DESCRIPTION
## Summary
- expose `ObjectId` in dashboard evaluation sandbox so dashboard scripts can use it
- add regression test ensuring `ObjectId` is available during evaluation
- surface dashboard evaluation errors on the UI and only append results when successful
- extend error-handling test to verify no result is returned when evaluation fails

## Testing
- `npm run lint`
- `npm test` (fails: Timeout of 2000ms exceeded)


------
https://chatgpt.com/codex/tasks/task_e_68b74d87b2d08324a4edc946607626ca