### PR TITLE
feat: add dashboard grid component

### DIFF
--- a/frontend/src/dashboard-result/dashboard-grid/dashboard-grid.html
+++ b/frontend/src/dashboard-result/dashboard-grid/dashboard-grid.html
@@ -1,0 +1,9 @@
+<div class="grid gap-2" :style="{ gridTemplateColumns: gridTemplateColumns }">
+  <template v-for="(row, rowIndex) in value.$grid" :key="rowIndex">
+    <dashboard-result
+      v-for="(cell, colIndex) in row"
+      :key="rowIndex + '-' + colIndex"
+      :result="cell">
+    </dashboard-result>
+  </template>
+</div>

--- a/frontend/src/dashboard-result/dashboard-grid/dashboard-grid.js
+++ b/frontend/src/dashboard-result/dashboard-grid/dashboard-grid.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const template = require('./dashboard-grid.html');
+
+module.exports = app => app.component('dashboard-grid', {
+  template: template,
+  props: ['value'],
+  computed: {
+    columns() {
+      const grid = this.value && this.value.$grid;
+      if (!Array.isArray(grid) || grid.length === 0) {
+        return 1;
+      }
+      return Math.max(...grid.map(row => Array.isArray(row) ? row.length : 0));
+    },
+    gridTemplateColumns() {
+      return `repeat(${this.columns}, minmax(0, 1fr))`;
+    }
+  }
+});

--- a/frontend/src/dashboard-result/dashboard-result.js
+++ b/frontend/src/dashboard-result/dashboard-result.js
@@ -31,6 +31,9 @@ module.exports = app => app.component('dashboard-result', {
       if (value.$text) {
         return 'dashboard-text';
       }
+      if (value.$grid) {
+        return 'dashboard-grid';
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- render dashboard results in a grid via new `dashboard-grid` component
- handle `$grid` objects in dashboard result dispatcher

## Testing
- `npm run lint`
- `npm test` *(fails: Timeout of 2000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68bae3daf0148324ab1360818accbe2d