### PR TITLE
Use backend evaluation for model search filters

### DIFF
--- a/backend/actions/Model/getDocuments.js
+++ b/backend/actions/Model/getDocuments.js
@@ -2,7 +2,7 @@
 
 const Archetype = require('archetype');
 const removeSpecifiedPaths = require('../../helpers/removeSpecifiedPaths');
-const { EJSON } = require('bson');
+const evaluateFilter = require('../../helpers/evaluateFilter');
 const authorize = require('../../authorize');
 
 const GetDocumentsParams = new Archetype({
@@ -20,8 +20,8 @@ const GetDocumentsParams = new Archetype({
     $required: true,
     $default: 0
   },
-  filter: {
-    $type: Archetype.Any
+  searchText: {
+    $type: 'string'
   },
   sort: {
     $type: Archetype.Any
@@ -36,20 +36,15 @@ module.exports = ({ db }) => async function getDocuments(params) {
   const { roles } = params;
   await authorize('Model.getDocuments', roles);
 
-  let { filter } = params;
-  if (filter != null && Object.keys(filter).length > 0) {
-    filter = EJSON.parse(filter);
-  }
-  const { model, limit, skip, sort } = params;
+  const { model, limit, skip, sort, searchText } = params;
 
   const Model = db.models[model];
   if (Model == null) {
     throw new Error(`Model ${model} not found`);
   }
 
-  if (typeof filter === 'string') {
-    filter = { '$**': filter };
-  }
+  const parsedFilter = evaluateFilter(searchText);
+  const filter = parsedFilter == null ? {} : parsedFilter;
 
   const hasSort = typeof sort === 'object' && sort != null && Object.keys(sort).length > 0;
   const sortObj = hasSort ? { ...sort } : {};
@@ -57,7 +52,7 @@ module.exports = ({ db }) => async function getDocuments(params) {
     sortObj._id = -1;
   }
   const cursor = await Model.
-    find(filter == null ? {} : filter).
+    find(filter).
     limit(limit).
     skip(skip).
     sort(sortObj).
@@ -78,7 +73,7 @@ module.exports = ({ db }) => async function getDocuments(params) {
   }
   removeSpecifiedPaths(schemaPaths, '.$*');
 
-  const numDocuments = filter == null ?
+  const numDocuments = parsedFilter == null ?
     await Model.estimatedDocumentCount() :
     await Model.countDocuments(filter);
 

--- a/backend/helpers/evaluateFilter.js
+++ b/backend/helpers/evaluateFilter.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const vm = require('vm');
+
+const evaluate = typeof vm.evaluate === 'function' ?
+  vm.evaluate.bind(vm) :
+  (code, context) => {
+    const script = new vm.Script(code, { displayErrors: true });
+    return script.runInContext(context, { timeout: 1000 });
+  };
+
+const ObjectId = new Proxy(mongoose.Types.ObjectId, {
+  apply(target, thisArg, argumentsList) {
+    return new target(...argumentsList);
+  }
+});
+
+module.exports = function evaluateFilter(searchText) {
+  if (searchText == null) {
+    return null;
+  }
+
+  const normalized = String(searchText);
+  if (normalized.trim().length === 0) {
+    return null;
+  }
+
+  const context = vm.createContext({
+    ObjectId,
+    Date,
+    Math
+  });
+
+  let result;
+  try {
+    result = evaluate(`(${normalized})`, context);
+  } catch (err) {
+    throw new Error(`Invalid search filter: ${err.message}`);
+  }
+
+  if (result == null) {
+    return result;
+  }
+
+  if (typeof result === 'object') {
+    return result;
+  }
+
+  if (typeof result === 'string') {
+    return { '$**': result };
+  }
+
+  throw new Error('Invalid search filter: must evaluate to an object or string');
+};

--- a/backend/helpers/evaluateFilter.js
+++ b/backend/helpers/evaluateFilter.js
@@ -47,9 +47,5 @@ module.exports = function evaluateFilter(searchText) {
     return result;
   }
 
-  if (typeof result === 'string') {
-    return { '$**': result };
-  }
-
-  throw new Error('Invalid search filter: must evaluate to an object or string');
+  throw new Error('Invalid search filter: must evaluate to an object');
 };

--- a/frontend/src/export-query-results/export-query-results.js
+++ b/frontend/src/export-query-results/export-query-results.js
@@ -9,7 +9,7 @@ appendCSS(require('./export-query-results.css'));
 
 module.exports = app => app.component('export-query-results', {
   template: template,
-  props: ['schemaPaths', 'filter', 'currentModel'],
+  props: ['schemaPaths', 'searchText', 'currentModel'],
   emits: ['done'],
   data: () => ({
     shouldExport: {}
@@ -26,8 +26,8 @@ module.exports = app => app.component('export-query-results', {
         model: this.currentModel,
         propertiesToInclude: Object.keys(this.shouldExport).filter(key => this.shouldExport[key])
       };
-      if (this.filter) {
-        params.filter = this.filter;
+      if (typeof this.searchText === 'string' && this.searchText.trim().length > 0) {
+        params.searchText = this.searchText;
       }
       await api.Model.exportQueryResults(params);
 

--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -152,7 +152,7 @@
       <div class="modal-exit" @click="shouldShowExportModal = false">&times;</div>
       <export-query-results
         :schemaPaths="schemaPaths"
-        :filter="filter"
+        :search-text="searchText"
         :currentModel="currentModel"
         @done="shouldShowExportModal = false">
       </export-query-results>

--- a/test/Model.getDocuments.filter.test.js
+++ b/test/Model.getDocuments.filter.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const assert = require('assert');
+const mongoose = require('mongoose');
+const { actions, connection } = require('./setup.test');
+
+describe('Model.getDocuments() searchText', function() {
+  const FilterTest = connection.model('FilterTest', new mongoose.Schema({
+    name: String,
+    createdAt: Date,
+    value: Number
+  }));
+
+  afterEach(async function() {
+    await FilterTest.deleteMany();
+  });
+
+  it('parses object filters from searchText', async function() {
+    const matching = await FilterTest.create({ name: 'alpha' });
+    await FilterTest.create({ name: 'beta' });
+
+    const res = await actions.Model.getDocuments({
+      model: 'FilterTest',
+      searchText: '{ name: "alpha" }',
+      roles: ['admin']
+    });
+
+    assert.strictEqual(res.docs.length, 1);
+    assert.strictEqual(res.docs[0]._id.toString(), matching._id.toString());
+  });
+
+  it('supports ObjectId helper in searchText', async function() {
+    const doc = await FilterTest.create({ name: 'gamma' });
+    await FilterTest.create({ name: 'delta' });
+
+    const res = await actions.Model.getDocuments({
+      model: 'FilterTest',
+      searchText: `{ _id: ObjectId("${doc._id.toString()}") }`,
+      roles: ['admin']
+    });
+
+    assert.strictEqual(res.docs.length, 1);
+    assert.strictEqual(res.docs[0]._id.toString(), doc._id.toString());
+  });
+
+  it('supports calling ObjectId without new keyword', async function() {
+    const manualId = new mongoose.Types.ObjectId('0'.repeat(24));
+    await FilterTest.create({ _id: manualId, name: 'manual' });
+    await FilterTest.create({ name: 'other' });
+
+    const res = await actions.Model.getDocuments({
+      model: 'FilterTest',
+      searchText: "{ _id: ObjectId('0'.repeat(24)) }",
+      roles: ['admin']
+    });
+
+    assert.strictEqual(res.docs.length, 1);
+    assert.strictEqual(res.docs[0]._id.toString(), manualId.toString());
+  });
+
+  it('provides Date and Math globals for searchText', async function() {
+    const early = await FilterTest.create({ name: 'early', createdAt: new Date('2020-01-01'), value: 1 });
+    await FilterTest.create({ name: 'late', createdAt: new Date('2022-01-01'), value: 10 });
+
+    const res = await actions.Model.getDocuments({
+      model: 'FilterTest',
+      searchText: '{ createdAt: { $lt: new Date("2021-01-01") }, value: { $lt: Math.ceil(2.3) } }',
+      roles: ['admin']
+    });
+
+    assert.strictEqual(res.docs.length, 1);
+    assert.strictEqual(res.docs[0]._id.toString(), early._id.toString());
+  });
+});


### PR DESCRIPTION
## Summary
- remove the frontend filter mirror and use `searchText` when loading documents and exporting results
- evaluate incoming search strings on the backend with `vm`, including an ObjectId proxy helper so direct `ObjectId()` calls work alongside `Date` and `Math`
- cover the new evaluation flow with tests around `Model.getDocuments()`, including calling `ObjectId` without `new`

## Testing
- npm test -- Model.getDocuments.filter.test.js *(fails: MongoDB server is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1c6cd5d48324bdaf3ae2669b2f65