### PR TITLE
Add shift-click range selection in models view

### DIFF
--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -51,10 +51,10 @@
           <button
             @click="stagingSelect"
             type="button"
-            :class="{ 'bg-ultramarine-500 ring-inset ring-2 ring-gray-300 hover:bg-ultramarine-600': selectMultiple }"
-            class="rounded bg-ultramarine-600 px-2 py-2 text-sm font-semibold text-white shadow-sm hover:bg-ultramarine-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ultramarine-600"
+            :class="{ 'bg-gray-500 ring-inset ring-2 ring-gray-300 hover:bg-gray-600': selectMultiple, 'bg-ultramarine-600 hover:bg-ultramarine-500' : !selectMultiple }"
+            class="rounded px-2 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ultramarine-600"
           >
-            Select
+            {{ selectMultiple ? 'Cancel' : 'Select' }}
           </button>
           <button
             v-show="selectMultiple"

--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -125,7 +125,7 @@
           </th>
         </thead>
         <tbody>
-          <tr v-for="document in documents" @click="handleDocumentClick(document)" :key="document._id">
+          <tr v-for="document in documents" @click="handleDocumentClick(document, $event)" :key="document._id">
             <td v-for="schemaPath in filteredPaths" :class="{ 'bg-blue-200': selectedDocuments.some(x => x._id.toString() === document._id.toString()) }">
               <component
                 :is="getComponentForPath(schemaPath)"
@@ -137,7 +137,7 @@
         </tbody>
       </table>
       <div v-if="outputType === 'json'">
-        <div v-for="document in documents" @click="handleDocumentClick(document)" :key="document._id" :class="{ 'bg-blue-200': selectedDocuments.some(x => x._id.toString() === document._id.toString()) }">
+        <div v-for="document in documents" @click="handleDocumentClick(document, $event)" :key="document._id" :class="{ 'bg-blue-200': selectedDocuments.some(x => x._id.toString() === document._id.toString()) }">
           <list-json :value="filterDocument(document)">
           </list-json>
         </div>

--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -43,7 +43,8 @@ module.exports = app => app.component('models', {
     scrollHeight: 0,
     interval: null,
     outputType: 'table', // json, table
-    hideSidebar: null
+    hideSidebar: null,
+    lastSelectedIndex: null
   }),
   created() {
     this.currentModel = this.model;
@@ -216,6 +217,7 @@ module.exports = app => app.component('models', {
       this.schemaPaths = [];
       this.numDocuments = null;
       this.loadedAllDocs = false;
+      this.lastSelectedIndex = null;
 
       let docsCount = 0;
       let schemaPathsReceived = false;
@@ -389,17 +391,47 @@ module.exports = app => app.component('models', {
       }
       this.edittingDoc = null;
     },
-    handleDocumentClick(document) {
+    handleDocumentClick(document, event) {
       console.log(this.selectedDocuments);
       if (this.selectMultiple) {
+        const documentIndex = this.documents.findIndex(doc => doc._id.toString() == document._id.toString());
+        if (event?.shiftKey && this.selectedDocuments.length > 0) {
+          let anchorIndex = this.lastSelectedIndex;
+          if (anchorIndex == null || anchorIndex === -1) {
+            const anchorDoc = this.selectedDocuments[this.selectedDocuments.length - 1];
+            if (anchorDoc) {
+              anchorIndex = this.documents.findIndex(doc => doc._id.toString() == anchorDoc._id.toString());
+            }
+          }
+          if (anchorIndex != null && anchorIndex !== -1 && documentIndex !== -1) {
+            const start = Math.min(anchorIndex, documentIndex);
+            const end = Math.max(anchorIndex, documentIndex);
+            for (let i = start; i <= end; i++) {
+              const docInRange = this.documents[i];
+              const existsInRange = this.selectedDocuments.some(x => x._id.toString() == docInRange._id.toString());
+              if (!existsInRange) {
+                this.selectedDocuments.push(docInRange);
+              }
+            }
+            this.lastSelectedIndex = documentIndex;
+            return;
+          }
+        }
         const exists = this.selectedDocuments.find(x => x._id.toString() == document._id.toString());
         if (exists) {
           const index = this.selectedDocuments.findIndex(x => x._id.toString() == document._id.toString());
           if (index !== -1) {
             this.selectedDocuments.splice(index, 1);
+            if (this.selectedDocuments.length === 0) {
+              this.lastSelectedIndex = null;
+            } else {
+              const lastDoc = this.selectedDocuments[this.selectedDocuments.length - 1];
+              this.lastSelectedIndex = this.documents.findIndex(doc => doc._id.toString() == lastDoc._id.toString());
+            }
           }
         } else {
           this.selectedDocuments.push(document);
+          this.lastSelectedIndex = documentIndex;
         }
       } else {
         this.$router.push('/model/' + this.currentModel + '/document/' + document._id);
@@ -413,18 +445,21 @@ module.exports = app => app.component('models', {
       });
       await this.getDocuments();
       this.selectedDocuments.length = 0;
+      this.lastSelectedIndex = null;
       this.shouldShowDeleteMultipleModal = false;
       this.selectMultiple = false;
     },
     async updateDocuments() {
       await this.getDocuments();
       this.selectedDocuments.length = 0;
+      this.lastSelectedIndex = null;
       this.selectMultiple = false;
     },
     stagingSelect() {
       if (this.selectMultiple) {
         this.selectMultiple = false;
         this.selectedDocuments.length = 0;
+        this.lastSelectedIndex = null;
       } else {
         this.selectMultiple = true;
       }

--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -392,23 +392,17 @@ module.exports = app => app.component('models', {
       this.edittingDoc = null;
     },
     handleDocumentClick(document, event) {
-      console.log(this.selectedDocuments);
       if (this.selectMultiple) {
         const documentIndex = this.documents.findIndex(doc => doc._id.toString() == document._id.toString());
         if (event?.shiftKey && this.selectedDocuments.length > 0) {
-          let anchorIndex = this.lastSelectedIndex;
-          if (anchorIndex == null || anchorIndex === -1) {
-            const anchorDoc = this.selectedDocuments[this.selectedDocuments.length - 1];
-            if (anchorDoc) {
-              anchorIndex = this.documents.findIndex(doc => doc._id.toString() == anchorDoc._id.toString());
-            }
-          }
+          const anchorIndex = this.lastSelectedIndex;
           if (anchorIndex != null && anchorIndex !== -1 && documentIndex !== -1) {
             const start = Math.min(anchorIndex, documentIndex);
             const end = Math.max(anchorIndex, documentIndex);
+            const selectedDocumentIds = new Set(this.selectedDocuments.map(doc => doc._id.toString()));
             for (let i = start; i <= end; i++) {
               const docInRange = this.documents[i];
-              const existsInRange = this.selectedDocuments.some(x => x._id.toString() == docInRange._id.toString());
+              const existsInRange = selectedDocumentIds.has(docInRange._id.toString());
               if (!existsInRange) {
                 this.selectedDocuments.push(docInRange);
               }
@@ -417,17 +411,14 @@ module.exports = app => app.component('models', {
             return;
           }
         }
-        const exists = this.selectedDocuments.find(x => x._id.toString() == document._id.toString());
-        if (exists) {
-          const index = this.selectedDocuments.findIndex(x => x._id.toString() == document._id.toString());
-          if (index !== -1) {
-            this.selectedDocuments.splice(index, 1);
-            if (this.selectedDocuments.length === 0) {
-              this.lastSelectedIndex = null;
-            } else {
-              const lastDoc = this.selectedDocuments[this.selectedDocuments.length - 1];
-              this.lastSelectedIndex = this.documents.findIndex(doc => doc._id.toString() == lastDoc._id.toString());
-            }
+        const index = this.selectedDocuments.findIndex(x => x._id.toString() == document._id.toString());
+        if (index !== -1) {
+          this.selectedDocuments.splice(index, 1);
+          if (this.selectedDocuments.length === 0) {
+            this.lastSelectedIndex = null;
+          } else {
+            const lastDoc = this.selectedDocuments[this.selectedDocuments.length - 1];
+            this.lastSelectedIndex = this.documents.findIndex(doc => doc._id.toString() == lastDoc._id.toString());
           }
         } else {
           this.selectedDocuments.push(document);


### PR DESCRIPTION
## Summary
- track the last selected document index while in select mode
- enable shift+click range selection across both table and JSON document layouts
- clear the range anchor when the selection is reset by other actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec7ef83b48324b11c52e40909a9b9