### PR TITLE
feat: allow using OpenAI API key for chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If you have a Mongoose Studio Pro API key, you can set it as follows:
 const opts = process.env.MONGOOSE_STUDIO_API_KEY ? { apiKey: process.env.MONGOOSE_STUDIO_API_KEY } : {};
 // Optionally specify which ChatGPT model to use for chat messages
 opts.model = 'gpt-4o-mini';
+// Provide your own OpenAI API key to run chat completions locally
+opts.openAIAPIKey = process.env.OPENAI_API_KEY;
 
 // Mount Mongoose Studio on '/studio'
 app.use('/studio', await studio('/studio/api', mongoose, opts));
@@ -52,7 +54,9 @@ const { execSync } = require('child_process');
 const opts = {
   apiKey: process.env.MONGOOSE_STUDIO_API_KEY,
   // Optionally specify which ChatGPT model to use for chat messages
-  model: 'gpt-4o-mini'
+  model: 'gpt-4o-mini',
+  // Provide your own OpenAI API key to run chat completions locally
+  openAIAPIKey: process.env.OPENAI_API_KEY
 };
 console.log('Creating Mongoose studio', opts);
 require('@mongoosejs/studio/frontend')(`/.netlify/functions/studio`, true, opts).then(() => {
@@ -70,7 +74,8 @@ const mongoose = require('mongoose');
 
 const handler = require('@mongoosejs/studio/backend/netlify')({
   apiKey: process.env.MONGOOSE_STUDIO_API_KEY,
-  model: 'gpt-4o-mini'
+  model: 'gpt-4o-mini',
+  openAIAPIKey: process.env.OPENAI_API_KEY
 }).handler;
 
 let conn = null;


### PR DESCRIPTION
## Summary
- allow chat message creation and summarization to call the OpenAI API when an `openAIAPIKey` option is provided while preserving the existing Netlify fallback
- document the new `openAIAPIKey` option in the README examples

## Testing
- npm test *(fails: timeout in before/after hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68e02a2413888324ae489853a74f51a9