### PR TITLE
Add enum support to model filter autocomplete

### DIFF
--- a/backend/actions/Model/getDocument.js
+++ b/backend/actions/Model/getDocument.js
@@ -34,10 +34,15 @@ module.exports = ({ db }) => async function getDocument(params) {
     orFail();
   const schemaPaths = {};
   for (const path of Object.keys(Model.schema.paths)) {
+    const schemaPath = Model.schema.paths[path];
+    const rawEnumValues = Array.isArray(schemaPath?.options?.enum) && schemaPath.options.enum.length > 0 ?
+      schemaPath.options.enum : schemaPath?.enumValues;
+    const enumValues = Array.isArray(rawEnumValues) ? rawEnumValues.filter(value => value != null) : undefined;
     schemaPaths[path] = {
-      instance: Model.schema.paths[path].instance,
+      instance: schemaPath.instance,
       path,
-      ref: Model.schema.paths[path].options?.ref
+      ref: schemaPath.options?.ref,
+      enumValues: Array.isArray(enumValues) && enumValues.length > 0 ? enumValues : undefined
     };
   }
   removeSpecifiedPaths(schemaPaths, '.$*');

--- a/backend/actions/Model/getDocuments.js
+++ b/backend/actions/Model/getDocuments.js
@@ -64,11 +64,16 @@ module.exports = ({ db }) => async function getDocuments(params) {
 
   const schemaPaths = {};
   for (const path of Object.keys(Model.schema.paths)) {
+    const schemaPath = Model.schema.paths[path];
+    const rawEnumValues = Array.isArray(schemaPath?.options?.enum) && schemaPath.options.enum.length > 0 ?
+      schemaPath.options.enum : schemaPath?.enumValues;
+    const enumValues = Array.isArray(rawEnumValues) ? rawEnumValues.filter(value => value != null) : undefined;
     schemaPaths[path] = {
-      instance: Model.schema.paths[path].instance,
+      instance: schemaPath.instance,
       path,
-      ref: Model.schema.paths[path].options?.ref,
-      required: Model.schema.paths[path].options?.required
+      ref: schemaPath.options?.ref,
+      required: schemaPath.options?.required,
+      enumValues: Array.isArray(enumValues) && enumValues.length > 0 ? enumValues : undefined
     };
   }
   removeSpecifiedPaths(schemaPaths, '.$*');

--- a/backend/actions/Model/getDocumentsStream.js
+++ b/backend/actions/Model/getDocumentsStream.js
@@ -54,11 +54,16 @@ module.exports = ({ db }) => async function* getDocumentsStream(params) {
 
   const schemaPaths = {};
   for (const path of Object.keys(Model.schema.paths)) {
+    const schemaPath = Model.schema.paths[path];
+    const rawEnumValues = Array.isArray(schemaPath?.options?.enum) && schemaPath.options.enum.length > 0 ?
+      schemaPath.options.enum : schemaPath?.enumValues;
+    const enumValues = Array.isArray(rawEnumValues) ? rawEnumValues.filter(value => value != null) : undefined;
     schemaPaths[path] = {
-      instance: Model.schema.paths[path].instance,
+      instance: schemaPath.instance,
       path,
-      ref: Model.schema.paths[path].options?.ref,
-      required: Model.schema.paths[path].options?.required
+      ref: schemaPath.options?.ref,
+      required: schemaPath.options?.required,
+      enumValues: Array.isArray(enumValues) && enumValues.length > 0 ? enumValues : undefined
     };
   }
   removeSpecifiedPaths(schemaPaths, '.$*');

--- a/backend/db/dashboardSchema.js
+++ b/backend/db/dashboardSchema.js
@@ -25,11 +25,16 @@ dashboardSchema.methods.evaluate = async function evaluate() {
     const schemaPaths = {};
     const Model = this.constructor.db.model(result.$document?.constructor?.modelName);
     for (const path of Object.keys(Model.schema.paths)) {
+      const schemaPath = Model.schema.paths[path];
+      const rawEnumValues = Array.isArray(schemaPath?.options?.enum) && schemaPath.options.enum.length > 0 ?
+        schemaPath.options.enum : schemaPath?.enumValues;
+      const enumValues = Array.isArray(rawEnumValues) ? rawEnumValues.filter(value => value != null) : undefined;
       schemaPaths[path] = {
-        instance: Model.schema.paths[path].instance,
+        instance: schemaPath.instance,
         path,
-        ref: Model.schema.paths[path].options?.ref,
-        required: Model.schema.paths[path].options?.required
+        ref: schemaPath.options?.ref,
+        required: schemaPath.options?.required,
+        enumValues: Array.isArray(enumValues) && enumValues.length > 0 ? enumValues : undefined
       };
     }
     result.$document.schemaPaths = schemaPaths;

--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -37,7 +37,7 @@
           <form @submit.prevent="search" class="relative flex-grow m-0">
             <input ref="searchInput" class="w-full font-mono rounded-md p-1 border border-gray-300 outline-gray-300 text-lg focus:ring-1 focus:ring-ultramarine-200 focus:ring-offset-0 focus:outline-none" type="text" placeholder="Filter" v-model="searchText" @click="initFilter" @input="updateAutocomplete" @keydown="handleKeyDown" />
             <ul v-if="autocompleteSuggestions.length" class="absolute z-[9999] bg-white border border-gray-300 rounded mt-1 w-full max-h-40 overflow-y-auto shadow">
-              <li v-for="(suggestion, index) in autocompleteSuggestions" :key="suggestion" class="px-2 py-1 cursor-pointer" :class="{ 'bg-ultramarine-100': index === autocompleteIndex }" @mousedown.prevent="applySuggestion(index)">{{ suggestion }}</li>
+              <li v-for="(suggestion, index) in autocompleteSuggestions" :key="suggestion.display + '-' + index" class="px-2 py-1 cursor-pointer" :class="{ 'bg-ultramarine-100': index === autocompleteIndex }" @mousedown.prevent="applySuggestion(index)">{{ suggestion.display }}</li>
             </ul>
           </form>
           <div>


### PR DESCRIPTION
## Summary
- include schema enum values in the Model schemaPaths payloads so the client can access them
- extend the models view autocomplete to surface enum value suggestions when typing after a field colon

## Testing
- npm test *(fails: before/after hooks time out in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42fc9af50832481537abdb66f27dc