### PR TITLE
Nicer formatting for long document detail properties

### DIFF
--- a/frontend/src/detail-default/detail-default.html
+++ b/frontend/src/detail-default/detail-default.html
@@ -1,3 +1,3 @@
-<div>
-  {{value}}
+<div class="w-full">
+  <pre class="w-full whitespace-pre-wrap break-words font-mono text-sm text-gray-700 m-0">{{displayValue}}</pre>
 </div>

--- a/frontend/src/detail-default/detail-default.js
+++ b/frontend/src/detail-default/detail-default.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const template = require('./detail-default.html');
-
 module.exports = app => app.component('detail-default', {
   template: template,
   props: ['value'],
@@ -13,7 +12,17 @@ module.exports = app => app.component('detail-default', {
       if (this.value === undefined) {
         return 'undefined';
       }
-      return this.value;
+      if (typeof this.value === 'string') {
+        return this.value;
+      }
+      if (typeof this.value === 'number' || typeof this.value === 'boolean' || typeof this.value === 'bigint') {
+        return String(this.value);
+      }
+      try {
+        return JSON.stringify(this.value, null, 2);
+      } catch (err) {
+        return String(this.value);
+      }
     }
   }
 });

--- a/frontend/src/document-details/document-property/document-property.css
+++ b/frontend/src/document-details/document-property/document-property.css
@@ -21,18 +21,3 @@
     float: right;
     margin-top: -7px;
   }
-
-  .truncated-value-container,
-  .expanded-value-container {
-    position: relative;
-  }
-
-  .truncated-value-container button,
-  .expanded-value-container button {
-    transition: all 0.2s ease;
-  }
-
-  .truncated-value-container button:hover,
-  .expanded-value-container button:hover {
-    transform: translateX(2px);
-  }

--- a/frontend/src/document-details/document-property/document-property.html
+++ b/frontend/src/document-details/document-property/document-property.html
@@ -68,11 +68,11 @@
     </div>
     <div v-else>
       <!-- Show truncated or full value based on needsTruncation and isValueExpanded -->
-      <div v-if="needsTruncation && !isValueExpanded" class="truncated-value-container">
+      <div v-if="needsTruncation && !isValueExpanded" class="relative">
         <div class="text-gray-700 whitespace-pre-wrap break-words font-mono text-sm">{{truncatedString}}</div>
         <button
           @click="toggleValueExpansion"
-          class="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium flex items-center gap-1"
+          class="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium flex items-center gap-1 transform transition-all duration-200 ease-in-out hover:translate-x-0.5"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
@@ -80,11 +80,11 @@
           Show more ({{valueAsString.length}} characters)
         </button>
       </div>
-      <div v-else-if="needsTruncation && isValueExpanded" class="expanded-value-container">
+      <div v-else-if="needsTruncation && isValueExpanded" class="relative">
         <component :is="getComponentForPath(path)" :value="getValueForPath(path.path)"></component>
         <button
           @click="toggleValueExpansion"
-          class="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium flex items-center gap-1"
+          class="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium flex items-center gap-1 transform transition-all duration-200 ease-in-out hover:translate-x-0.5"
         >
           <svg class="w-4 h-4 rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>


### PR DESCRIPTION
## Summary
- replace the detail-default stylesheet with Tailwind utility classes so expanded document values retain formatting without custom CSS
- swap truncated/expanded document value containers to Tailwind utilities and keep the expand/collapse button transition in markup

## Testing
- npm test *(fails: "before all" hook timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68f0fa06edd083249333f31494c41ea4