### PR TITLE
Persist models view preference

### DIFF
--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -98,14 +98,14 @@
           </button>
           <span class="isolate inline-flex rounded-md shadow-sm">
             <button
-              @click="outputType = 'table'"
+              @click="setOutputType('table')"
               type="button"
               class="relative inline-flex items-center rounded-none rounded-l-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10"
               :class="outputType === 'table' ? 'bg-gray-200' : 'bg-white'">
               <img class="h-5 w-5" src="images/table.svg">
             </button>
             <button
-              @click="outputType = 'json'"
+              @click="setOutputType('json')"
               type="button"
               class="relative -ml-px inline-flex items-center rounded-none rounded-r-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10"
               :class="outputType === 'json' ? 'bg-gray-200' : 'bg-white'">

--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -38,6 +38,7 @@ const QUERY_SELECTORS = [
 appendCSS(require('./models.css'));
 
 const limit = 20;
+const OUTPUT_TYPE_STORAGE_KEY = 'studio:model-output-type';
 
 module.exports = app => app.component('models', {
   template: template,
@@ -80,6 +81,7 @@ module.exports = app => app.component('models', {
   created() {
     this.currentModel = this.model;
     this.buildAutocompleteTrie();
+    this.loadOutputPreference();
   },
   beforeDestroy() {
     document.removeEventListener('scroll', this.onScroll, true);
@@ -106,6 +108,24 @@ module.exports = app => app.component('models', {
           .map(path => path?.path)
           .filter(path => typeof path === 'string' && path.length > 0);
         this.autocompleteTrie.bulkInsert(paths, 10);
+      }
+    },
+    loadOutputPreference() {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return;
+      }
+      const storedPreference = window.localStorage.getItem(OUTPUT_TYPE_STORAGE_KEY);
+      if (storedPreference === 'json' || storedPreference === 'table') {
+        this.outputType = storedPreference;
+      }
+    },
+    setOutputType(type) {
+      if (type !== 'json' && type !== 'table') {
+        return;
+      }
+      this.outputType = type;
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(OUTPUT_TYPE_STORAGE_KEY, type);
       }
     },
     buildDocumentFetchParams(options = {}) {


### PR DESCRIPTION
## Summary
- load the previously saved models table/json view preference from localStorage when the component is created
- persist updates to the table/json toggle so navigation reuses the stored preference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690237e9bf7883248b22b2621173b2ac