### PR TITLE
Link dashboard map pins to documents

### DIFF
--- a/frontend/src/dashboard-result/dashboard-map/dashboard-map.js
+++ b/frontend/src/dashboard-result/dashboard-map/dashboard-map.js
@@ -12,7 +12,26 @@ module.exports = app => app.component('dashboard-map', {
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
-    const layer = L.geoJSON(fc).addTo(map);
+    const defaultModel = this.value?.$featureCollection?.model;
+    const layer = L.geoJSON(fc, {
+      onEachFeature: (feature, layer) => {
+        const properties = feature?.properties || {};
+        const documentId = properties._id || properties.id || feature?.id;
+        const featureModel = properties.model || defaultModel;
+        const documentUrl = properties.documentUrl || (featureModel && documentId ? `#/model/${featureModel}/document/${documentId}` : null);
+
+        if (documentUrl) {
+          const anchor = document.createElement('a');
+          anchor.href = documentUrl;
+          anchor.target = '_blank';
+          anchor.rel = 'noopener noreferrer';
+          anchor.textContent = properties.name || properties.title || properties.label || documentId || 'View document';
+          layer.bindPopup(anchor);
+        } else if (documentId != null) {
+          layer.bindPopup(String(documentId));
+        }
+      }
+    }).addTo(map);
 
     this.$nextTick(() => {
       map.invalidateSize();


### PR DESCRIPTION
## Summary
- add per-feature popups in dashboard maps that link pins to their documents when model metadata is available
- preserve existing id popup fallback when no document link can be built

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211b4b4bcc832491234802eb8d7094)