### PR TITLE
Show map view in script output modal

### DIFF
--- a/frontend/src/chat/chat-message-script/chat-message-script.html
+++ b/frontend/src/chat/chat-message-script/chat-message-script.html
@@ -106,6 +106,10 @@
       <div class="absolute font-mono right-1 top-1 cursor-pointer text-xl" @click="showDetailModal = false;">&times;</div>
       <div class="h-full overflow-auto">
         <dashboard-chart v-if="message.executionResult?.output?.$chart" :value="message.executionResult?.output" :responsive="true" />
+        <dashboard-map
+          v-else-if="message.executionResult?.output?.$featureCollection"
+          :value="message.executionResult?.output"
+          height="80vh" />
         <pre v-else class="whitespace-pre-wrap">{{ message.executionResult?.output || 'No output' }}</pre>
       </div>
     </template>

--- a/frontend/src/dashboard-result/dashboard-map/dashboard-map.html
+++ b/frontend/src/dashboard-result/dashboard-map/dashboard-map.html
@@ -1,8 +1,8 @@
-<div class="py-2">
+<div class="py-2 h-full flex flex-col">
   <div v-if="header" class="border-b border-gray-100 px-2 pb-2 text-xl font-bold">
     {{header}}
   </div>
-  <div class="text-xl">
-    <div ref="map" class="w-full" style="height: 300px;"></div>
+  <div class="text-xl flex-1 min-h-[200px]">
+    <div ref="map" class="w-full h-full" :style="mapStyle"></div>
   </div>
 </div>

--- a/frontend/src/dashboard-result/dashboard-map/dashboard-map.js
+++ b/frontend/src/dashboard-result/dashboard-map/dashboard-map.js
@@ -5,7 +5,7 @@ const template = require('./dashboard-map.html');
 
 module.exports = app => app.component('dashboard-map', {
   template: template,
-  props: ['value'],
+  props: ['value', 'height'],
   mounted() {
     const fc = this.value.$featureCollection.featureCollection || this.value.$featureCollection;
     const map = L.map(this.$refs.map).setView([0, 0], 1);
@@ -23,6 +23,9 @@ module.exports = app => app.component('dashboard-map', {
     });
   },
   computed: {
+    mapStyle() {
+      return { height: this.height || '300px' };
+    },
     header() {
       if (this.value != null && this.value.$featureCollection.header) {
         return this.value.$featureCollection.header;


### PR DESCRIPTION
## Summary
- render the dashboard map in the script output modal when results include a feature collection
- allow dashboard map component to accept a custom height and fill available space

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b12407448324aeb7dd9f987390d1)