### PR TITLE
Add GeoJSON map view in document details

### DIFF
--- a/backend/actions/Model/getDocument.js
+++ b/backend/actions/Model/getDocument.js
@@ -34,13 +34,28 @@ module.exports = ({ db }) => async function getDocument(params) {
     orFail();
   const schemaPaths = {};
   for (const path of Object.keys(Model.schema.paths)) {
+    const schemaType = Model.schema.paths[path];
     schemaPaths[path] = {
-      instance: Model.schema.paths[path].instance,
+      instance: schemaType.instance,
       path,
-      ref: Model.schema.paths[path].options?.ref,
-      required: Model.schema.paths[path].options?.required,
-      enum: Model.schema.paths[path].options?.enum
+      ref: schemaType.options?.ref,
+      required: schemaType.options?.required,
+      enum: schemaType.options?.enum
     };
+
+    if (schemaType.schema) {
+      schemaPaths[path].schema = {};
+      for (const subpath of Object.keys(schemaType.schema.paths)) {
+        const subSchemaType = schemaType.schema.paths[subpath];
+        schemaPaths[path].schema[subpath] = {
+          instance: subSchemaType.instance,
+          path: subpath,
+          ref: subSchemaType.options?.ref,
+          required: subSchemaType.options?.required,
+          enum: subSchemaType.options?.enum
+        };
+      }
+    }
   }
   removeSpecifiedPaths(schemaPaths, '.$*');
 

--- a/frontend/src/detail-geojson/detail-geojson.css
+++ b/frontend/src/detail-geojson/detail-geojson.css
@@ -1,0 +1,63 @@
+.detail-geojson {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.detail-geojson .tab-header {
+  display: flex;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.detail-geojson .tab-button {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.detail-geojson .tab-button:hover {
+  background: #eef2ff;
+}
+
+.detail-geojson .tab-button.active {
+  color: #1d4ed8;
+  background: #e0e7ff;
+}
+
+.detail-geojson .raw-view {
+  padding: 0.75rem;
+  background: #fff;
+}
+
+.detail-geojson .geojson-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  margin: 0;
+  color: #111827;
+}
+
+.detail-geojson .map-view {
+  position: relative;
+}
+
+.detail-geojson .map-container {
+  height: 320px;
+  width: 100%;
+}
+
+.detail-geojson .map-error {
+  padding: 0.75rem;
+  color: #b91c1c;
+  background: #fef2f2;
+  border-top: 1px solid #fee2e2;
+  font-size: 0.875rem;
+}

--- a/frontend/src/detail-geojson/detail-geojson.html
+++ b/frontend/src/detail-geojson/detail-geojson.html
@@ -1,0 +1,26 @@
+<div class="detail-geojson">
+  <div class="tab-header">
+    <button
+      :class="['tab-button', activeTab === 'raw' ? 'active' : '']"
+      type="button"
+      @click="setActiveTab('raw')"
+    >
+      Raw
+    </button>
+    <button
+      :class="['tab-button', activeTab === 'map' ? 'active' : '']"
+      type="button"
+      @click="setActiveTab('map')"
+    >
+      Map
+    </button>
+  </div>
+
+  <div v-if="activeTab === 'raw'" class="raw-view">
+    <pre class="geojson-pre">{{formattedValue}}</pre>
+  </div>
+  <div v-else class="map-view">
+    <div ref="mapContainer" class="map-container"></div>
+    <div v-if="mapError" class="map-error">{{mapError}}</div>
+  </div>
+</div>

--- a/frontend/src/detail-geojson/detail-geojson.js
+++ b/frontend/src/detail-geojson/detail-geojson.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const template = require('./detail-geojson.html');
+const appendCSS = require('../appendCSS');
+
+appendCSS(require('./detail-geojson.css'));
+
+module.exports = app => app.component('detail-geojson', {
+  template,
+  props: ['value'],
+  data() {
+    return {
+      activeTab: 'raw',
+      map: null,
+      geoJsonLayer: null,
+      mapError: null
+    };
+  },
+  mounted() {
+    if (this.activeTab === 'map') {
+      this.initializeMap();
+    }
+  },
+  beforeDestroy() {
+    if (this.map) {
+      this.map.remove();
+      this.map = null;
+      this.geoJsonLayer = null;
+    }
+  },
+  watch: {
+    value: {
+      deep: true,
+      handler() {
+        if (this.map) {
+          this.renderGeoJSON();
+        }
+      }
+    }
+  },
+  computed: {
+    formattedValue() {
+      try {
+        return JSON.stringify(this.value, null, 2);
+      } catch (err) {
+        return String(this.value);
+      }
+    }
+  },
+  methods: {
+    setActiveTab(tab) {
+      this.activeTab = tab;
+      if (tab === 'map') {
+        this.$nextTick(() => this.initializeMap());
+      }
+    },
+    initializeMap() {
+      if (this.map || typeof L === 'undefined' || !this.$refs.mapContainer) {
+        this.renderGeoJSON();
+        return;
+      }
+
+      this.map = L.map(this.$refs.mapContainer).setView([0, 0], 2);
+
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+      }).addTo(this.map);
+
+      this.renderGeoJSON();
+    },
+    renderGeoJSON() {
+      if (!this.map || typeof L === 'undefined') {
+        return;
+      }
+
+      if (this.geoJsonLayer) {
+        this.geoJsonLayer.remove();
+        this.geoJsonLayer = null;
+      }
+
+      try {
+        this.geoJsonLayer = L.geoJSON(this.value);
+        this.geoJsonLayer.addTo(this.map);
+
+        const bounds = this.geoJsonLayer.getBounds();
+        if (bounds.isValid()) {
+          this.map.fitBounds(bounds, { padding: [20, 20] });
+        } else {
+          this.map.setView([0, 0], 2);
+        }
+        this.map.invalidateSize();
+        this.mapError = null;
+      } catch (err) {
+        this.mapError = 'Unable to render GeoJSON on the map.';
+      }
+    }
+  }
+});

--- a/frontend/src/document-details/document-property/document-property.html
+++ b/frontend/src/document-details/document-property/document-property.html
@@ -80,8 +80,11 @@
       </component>
     </div>
     <div v-else>
+      <div v-if="isGeoJSONSchemaPath(path)">
+        <component :is="getComponentForPath(path)" :value="getValueForPath(path.path)"></component>
+      </div>
       <!-- Show truncated or full value based on needsTruncation and isValueExpanded -->
-      <div v-if="needsTruncation && !isValueExpanded" class="relative">
+      <div v-else-if="needsTruncation && !isValueExpanded" class="relative">
         <div class="text-gray-700 whitespace-pre-wrap break-words font-mono text-sm">{{truncatedString}}</div>
         <button
           @click="toggleValueExpansion"
@@ -100,9 +103,9 @@
           class="mt-2 text-blue-600 hover:text-blue-800 text-sm font-medium flex items-center gap-1 transform transition-all duration-200 ease-in-out hover:translate-x-0.5"
         >
           <svg class="w-4 h-4 rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-          </svg>
-          Show less
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+        </svg>
+        Show less
         </button>
       </div>
       <div v-else>

--- a/frontend/src/document-details/document-property/document-property.js
+++ b/frontend/src/document-details/document-property/document-property.js
@@ -39,6 +39,9 @@ module.exports = app => app.component('document-property', {
       return String(value);
     },
     needsTruncation() {
+      if (this.isGeoJSONSchemaPath(this.path)) {
+        return false;
+      }
       // Truncate if value is longer than 200 characters
       return this.valueAsString.length > 200;
     },
@@ -58,6 +61,9 @@ module.exports = app => app.component('document-property', {
   },
   methods: {
     getComponentForPath(schemaPath) {
+      if (this.isGeoJSONSchemaPath(schemaPath)) {
+        return 'detail-geojson';
+      }
       if (schemaPath.instance === 'Array') {
         return 'detail-array';
       }
@@ -161,6 +167,20 @@ module.exports = app => app.component('document-property', {
       } else {
         fallbackCopy();
       }
+    },
+    isGeoJSONSchemaPath(schemaPath) {
+      const subSchema = schemaPath?.schema;
+      if (!subSchema) {
+        return false;
+      }
+
+      const typeSchema = subSchema.type;
+      const coordinatesSchema = subSchema.coordinates;
+
+      const validTypeEnum = Array.isArray(typeSchema?.enum) &&
+        typeSchema.enum.some(value => ['Point', 'Polygon', 'MultiPolygon'].includes(value));
+
+      return Boolean(coordinatesSchema) && validTypeEnum;
     }
   }
 });


### PR DESCRIPTION
## Summary
- include nested schema metadata in single-document fetches to identify GeoJSON-like subdocuments
- add a GeoJSON detail viewer with raw and Leaflet map tabs for matching fields
- render GeoJSON properties directly with the new tabbed view while keeping existing behaviors for other fields

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343bb3aef08324b82e8b5f750416ee)