### PR TITLE
Handle plain JSON dashboard results

### DIFF
--- a/frontend/src/dashboard-result/dashboard-object/dashboard-object.html
+++ b/frontend/src/dashboard-result/dashboard-object/dashboard-object.html
@@ -1,0 +1,6 @@
+<div class="py-2">
+  <div v-if="header" class="border-b border-gray-100 px-2 pb-2 text-xl font-bold">
+    {{header}}
+  </div>
+  <pre class="text-sm p-2 whitespace-pre-wrap overflow-auto"><code>{{formattedValue}}</code></pre>
+</div>

--- a/frontend/src/dashboard-result/dashboard-object/dashboard-object.js
+++ b/frontend/src/dashboard-result/dashboard-object/dashboard-object.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const template = require('./dashboard-object.html');
+
+module.exports = app => app.component('dashboard-object', {
+  template: template,
+  props: ['value'],
+  computed: {
+    header() {
+      return this.value?.header || null;
+    },
+    formattedValue() {
+      try {
+        return JSON.stringify(this.value, null, 2);
+      } catch (err) {
+        return String(this.value);
+      }
+    }
+  }
+});

--- a/frontend/src/dashboard-result/dashboard-result.js
+++ b/frontend/src/dashboard-result/dashboard-result.js
@@ -34,6 +34,7 @@ module.exports = app => app.component('dashboard-result', {
       if (value.$grid) {
         return 'dashboard-grid';
       }
+      return 'dashboard-object';
     }
   }
 });


### PR DESCRIPTION
## Summary
- add a dashboard object component to render plain JSON results
- fall back to the object view for dashboard outputs that are not charts or feature collections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a017d4b50832481528d3753bfc816)