### PR TITLE
Use CodeMirror editor for Mixed schema fields

### DIFF
--- a/frontend/src/document-details/document-property/document-property.js
+++ b/frontend/src/document-details/document-property/document-property.js
@@ -79,6 +79,9 @@ module.exports = app => app.component('document-property', {
       if (path.instance === 'Embedded') {
         return 'edit-subdocument';
       }
+      if (path.instance === 'Mixed') {
+        return 'edit-subdocument';
+      }
       if (path.instance === 'Boolean') {
         return 'edit-boolean';
       }


### PR DESCRIPTION
## Summary
- route Mixed schema fields to the subdocument editor so object values use the CodeMirror UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f68af1560832482876ef807e6011b)