### PR TITLE
Add tests for operator autocomplete brace handling

### DIFF
--- a/frontend/src/_util/document-search-autocomplete.js
+++ b/frontend/src/_util/document-search-autocomplete.js
@@ -82,9 +82,9 @@ function getAutocompleteContext(searchText, cursorPos) {
   
   // Check if we're in a value context (after a colon)
   // Match the last colon followed by optional whitespace and capture everything after
-  const valueMatch = before.match(/:\s*([^\s,\}\]:]*)$/);
+  const valueMatch = before.match(/:\s*(\{?\s*)([^\s,\}\]:]*)$/);
   if (valueMatch) {
-    const token = valueMatch[1];
+    const token = valueMatch[2];
     return {
       token,
       role: 'value',
@@ -159,9 +159,9 @@ function applySuggestion(searchText, cursorPos, suggestion) {
   const after = searchText.slice(cursorPos);
   
   // Check if we're in a value context
-  const valueMatch = before.match(/:\s*([^\s,\}\]:]*)$/);
+  const valueMatch = before.match(/:\s*(\{?\s*)([^\s,\}\]:]*)$/);
   if (valueMatch) {
-    const token = valueMatch[1];
+    const token = valueMatch[2];
     const start = cursorPos - token.length;
     let replacement = suggestion;
     let cursorOffset = replacement.length;

--- a/test/document-search-autocomplete.test.js
+++ b/test/document-search-autocomplete.test.js
@@ -234,6 +234,24 @@ describe('document-search-autocomplete', function() {
       assert.strictEqual(result.newCursorPos, '{ value: Math'.length);
     });
 
+    it('preserves opening brace when applying operator suggestions', function() {
+      const searchText = '{ _id: { $ex';
+      const cursorPos = searchText.length;
+      const result = applySuggestion(searchText, cursorPos, '$exists');
+
+      assert.strictEqual(result.text, '{ _id: { $exists');
+      assert.strictEqual(result.newCursorPos, '{ _id: { $exists'.length);
+    });
+
+    it('does not add a brace when completing function helpers', function() {
+      const searchText = '{ _id: object';
+      const cursorPos = searchText.length;
+      const result = applySuggestion(searchText, cursorPos, 'objectIdRange');
+
+      assert.strictEqual(result.text, '{ _id: objectIdRange()');
+      assert.strictEqual(result.newCursorPos, '{ _id: objectIdRange('.length);
+    });
+
     it('applies suggestion in field context with colon', function() {
       const searchText = '{ na';
       const cursorPos = searchText.length;


### PR DESCRIPTION
### Motivation
- Ensure operator autocomplete preserves an opening `{` when completing nested operators and that function helper completions do not insert a brace, fixing the previously observed typing flow breakage when completing operators.

### Description
- Update value-context parsing in `frontend/src/_util/document-search-autocomplete.js` to use the regex `/:\s*(\{?\s*)([^\s,\}\]:]*)$/` and use the second capture group as the token in both `getAutocompleteContext` and `applySuggestion` so an optional leading `{` and surrounding whitespace are preserved for operator suggestions.
- Add two tests in `test/document-search-autocomplete.test.js` to cover: preserving the opening brace for operator suggestions and ensuring function helper completion (e.g. `objectIdRange`) does not insert a brace.

### Testing
- Ran `npm test -- test/document-search-autocomplete.test.js`, which executed the test suite but the run failed due to Mocha `before all`/`after all` hook timeouts and did not complete (tests did not pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967bc41784c83249abee41bdd582d26)