### PR TITLE
Handle missing dashboardResults in dashboard load

### DIFF
--- a/frontend/src/dashboard/dashboard.js
+++ b/frontend/src/dashboard/dashboard.js
@@ -127,7 +127,7 @@ module.exports = {
       this.code = this.dashboard.code;
       this.title = this.dashboard.title;
       this.description = this.dashboard.description ?? '';
-      this.dashboardResults = dashboardResults;
+      this.dashboardResults = Array.isArray(dashboardResults) ? dashboardResults : [];
       if (this.shouldEvaluateDashboard()) {
         await this.evaluateDashboard();
         return;


### PR DESCRIPTION
### Motivation
- Prevent a runtime error when the backend omits `dashboardResults` (causing `Cannot read properties of undefined (reading 'length')`) by ensuring `dashboardResults` is always an array.

### Description
- Default `dashboardResults` to an empty array in `loadInitial()` by using `this.dashboardResults = Array.isArray(dashboardResults) ? dashboardResults : [];` to guard against `undefined`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d16d4f5a48324a0a2bad2b5717fb0)