### PR TITLE
Add 'Copy Document' option to document menu

### DIFF
--- a/frontend/src/document/document.html
+++ b/frontend/src/document/document.html
@@ -85,6 +85,13 @@
                 Add Field
               </button>
               <button
+                @click="copyDocument(); desktopMenuOpen = false"
+                type="button"
+                class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-blue-100"
+              >
+                Copy Document
+              </button>
+              <button
                 @click="shouldShowDeleteModal=true; desktopMenuOpen = false"
                 :disabled="!canManipulate"
                 :class="['flex items-center px-4 py-2 text-sm text-gray-700', !canManipulate ? 'cursor-not-allowed opacity-50' : 'hover:bg-red-100']"
@@ -156,6 +163,13 @@
                 class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-green-100"
               >
                 Add Field
+              </button>
+              <button
+                @click="copyDocument(); mobileMenuOpen = false"
+                type="button"
+                class="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-blue-100"
+              >
+                Copy Document
               </button>
               <button
                 @click="shouldShowDeleteModal=true; mobileMenuOpen = false"

--- a/frontend/src/document/document.js
+++ b/frontend/src/document/document.js
@@ -137,6 +137,43 @@ module.exports = app => app.component('document', {
         this.changes = {};
       }
     },
+    copyDocument() {
+      if (!this.document) {
+        return;
+      }
+
+      const textToCopy = JSON.stringify(this.document, null, 2);
+      const fallbackCopy = () => {
+        if (typeof document === 'undefined') {
+          return;
+        }
+        const textArea = document.createElement('textarea');
+        textArea.value = textToCopy;
+        textArea.setAttribute('readonly', '');
+        textArea.style.position = 'absolute';
+        textArea.style.left = '-9999px';
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+          document.execCommand('copy');
+        } finally {
+          document.body.removeChild(textArea);
+        }
+        this.$toast.success('Document copied!');
+      };
+
+      if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(textToCopy)
+          .then(() => {
+            this.$toast.success('Document copied!');
+          })
+          .catch(() => {
+            fallbackCopy();
+          });
+      } else {
+        fallbackCopy();
+      }
+    },
     goBack() {
       // Preserve query parameters when going back to models page
       this.$router.push({


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to copy the full document JSON from the document-details overflow (3-dot) menu on both desktop and mobile to simplify exporting or sharing a document.

### Description
- Add a "Copy Document" button to the desktop and mobile overflow menus in `frontend/src/document/document.html`.
- Implement `copyDocument()` in `frontend/src/document/document.js` which serializes `this.document` to pretty JSON and writes it to the clipboard using `navigator.clipboard.writeText` with a textarea fallback, and displays a success toast on completion.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e686039a883249cff38020dcacf72)