### PR TITLE
Prepopulate model query input while model list is loading

### DIFF
--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -64,6 +64,7 @@ module.exports = app => app.component('models', {
   }),
   created() {
     this.currentModel = this.model;
+    this.setSearchTextFromRoute();
     this.loadOutputPreference();
     this.loadSelectedGeoField();
     this.loadRecentlyViewedModels();
@@ -97,6 +98,7 @@ module.exports = app => app.component('models', {
       }
     };
     document.addEventListener('keydown', this.onCtrlP, true);
+    this.query = Object.assign({}, this.$route.query);
     const { models, readyState } = await api.Model.listModels();
     this.models = models;
     await this.loadModelCounts();
@@ -462,14 +464,17 @@ module.exports = app => app.component('models', {
 
       return params;
     },
-    async initSearchFromUrl() {
-      this.status = 'loading';
-      this.query = Object.assign({}, this.$route.query); // important that this is here before the if statements
+    setSearchTextFromRoute() {
       if (this.$route.query?.search) {
         this.searchText = this.$route.query.search;
       } else {
         this.searchText = '';
       }
+    },
+    async initSearchFromUrl() {
+      this.status = 'loading';
+      this.query = Object.assign({}, this.$route.query); // important that this is here before the if statements
+      this.setSearchTextFromRoute();
       if (this.$route.query?.sort) {
         const sort = eval(`(${this.$route.query.sort})`);
         const path = Object.keys(sort)[0];


### PR DESCRIPTION
### Motivation

- Ensure the document query input shows the route-provided `search` value immediately while models and documents are still loading so the UI reflects the user's query state sooner.

### Description

- Call `setSearchTextFromRoute()` in `created()` to populate `searchText` from `this.$route.query` early in the component lifecycle (`frontend/src/models/models.js`).
- Initialize `this.query` from `this.$route.query` at the start of `mounted()` so route state is available during initial async loads.
- Extracted duplicated route-to-search assignment into a new `setSearchTextFromRoute()` method and reuse it inside `initSearchFromUrl()` to remove repetition.
- Kept behavior of `initSearchFromUrl()` intact while moving the route-search logic to the new helper method.

### Testing

- Ran linting with `npx eslint frontend/src/models/models.js` and it completed successfully.
- Ran frontend tests with `npm run test:frontend` and the test suite passed (`5 passing`).
- Attempted a Playwright-based screenshot check but the browser invocation failed in CI (Chromium exited with a crash), so that UI capture step did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acaa04850c8324acb0400dcf83c1be)