### PR TITLE
Fix nested JSON model fields

### DIFF
--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -533,12 +533,37 @@ module.exports = app => app.component('models', {
     initializeDocumentData() {
       this.shouldShowCreateModal = true;
     },
+    setPathValue(target, path, value) {
+      if (typeof path !== 'string' || path.length === 0) {
+        return;
+      }
+
+      const parts = path.split('.');
+      let current = target;
+
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        const isLast = i === parts.length - 1;
+
+        if (isLast) {
+          current[part] = value;
+          return;
+        }
+
+        const nextPart = parts[i + 1];
+        const shouldCreateArray = /^\d+$/.test(nextPart);
+        if (current[part] == null || typeof current[part] !== 'object') {
+          current[part] = shouldCreateArray ? [] : {};
+        }
+        current = current[part];
+      }
+    },
     filterDocument(doc) {
       const filteredDoc = {};
       for (let i = 0; i < this.filteredPaths.length; i++) {
         const path = this.filteredPaths[i].path;
         const value = mpath.get(path, doc);
-        mpath.set(path, value, filteredDoc);
+        this.setPathValue(filteredDoc, path, value);
       }
       return filteredDoc;
     },

--- a/test/frontend/models.test.js
+++ b/test/frontend/models.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('assert');
+
+require('./setup');
+const modelsComponent = require('../../frontend/src/models/models');
+
+describe('models component', function() {
+  it('preserves nested properties in JSON view filters', function() {
+    const componentDef = modelsComponent({ component: (_name, def) => def });
+    const state = {
+      filteredPaths: [
+        { path: '_id' },
+        { path: 'profile.name.first' },
+        { path: 'profile.name.last' },
+        { path: 'settings.flags.0' }
+      ],
+      setPathValue: componentDef.methods.setPathValue
+    };
+
+    const filtered = componentDef.methods.filterDocument.call(state, {
+      _id: 'doc1',
+      profile: {
+        name: {
+          first: 'Ada',
+          last: 'Lovelace'
+        }
+      },
+      settings: {
+        flags: ['active', 'beta']
+      }
+    });
+
+    assert.deepStrictEqual(filtered, {
+      _id: 'doc1',
+      profile: {
+        name: {
+          first: 'Ada',
+          last: 'Lovelace'
+        }
+      },
+      settings: {
+        flags: ['active']
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- The JSON view was dropping nested dotted paths and numeric-indexed array fields when building the filtered document to render, so nested properties (e.g. `profile.name.first`, `settings.flags.0`) did not appear in the JSON view.

### Description
- Replaced `mpath.set(...)` usage in the models component with a new `setPathValue(target, path, value)` helper that creates missing object/array structure for dotted and indexed paths and assigns the value, and used it in `filterDocument` (file: `frontend/src/models/models.js`).
- Added a frontend regression test `test/frontend/models.test.js` that verifies dotted paths and array indices are preserved in the filtered JSON payload.

### Testing
- Ran the frontend tests with `npm run test:frontend -- --grep "models component"` and the new test passed (`1 passing`).
- Linted the changed files with `./node_modules/.bin/eslint frontend/src/models/models.js test/frontend/models.test.js` and it completed with no errors for the modified files.
- A full lint (`npm run lint`) was run and completed; it reported two pre-existing warnings in unrelated files (`frontend/src/dashboard/dashboard.js` and `frontend/src/navbar/navbar.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdca8052708324a8797eeaf3c46fd1)