### PR TITLE
Preserve JSON expansion state while documents load

### DIFF
--- a/frontend/src/list-json/list-json.js
+++ b/frontend/src/list-json/list-json.js
@@ -28,13 +28,6 @@ module.exports = app => app.component('list-json', {
       topLevelExpanded: false
     };
   },
-  watch: {
-    value: {
-      handler() {
-        this.resetCollapse();
-      }
-    }
-  },
   created() {
     this.resetCollapse();
     for (const field of this.expandedFields) {


### PR DESCRIPTION
### Motivation
- When new documents are loaded the JSON viewer was being reinitialized and collapsing any user-expanded nodes, likely caused by a watcher that reset collapse state on every `value` prop change.

### Description
- Remove the `value` watcher from `list-json` so collapse state is no longer reset on each prop update, preserving expanded JSON nodes during incremental loads and rerenders (file: `frontend/src/list-json/list-json.js`).

### Testing
- Ran linter: `npx eslint frontend/src/list-json/list-json.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c711d2a7808324a447ed80cce4202f)