### PR TITLE
Auto-focus search input on mount in document-search component

### DIFF
--- a/frontend/src/models/document-search/document-search.js
+++ b/frontend/src/models/document-search/document-search.js
@@ -41,6 +41,9 @@ module.exports = app => app.component('document-search', {
   created() {
     this.buildAutocompleteTrie();
   },
+  mounted() {
+    this.$refs.searchInput.focus();
+  },
   methods: {
     emitSearch() {
       this.$emit('input', this.searchText);


### PR DESCRIPTION
### Motivation
- Improve UX by automatically focusing the search input when the `document-search` component mounts to allow immediate keyboard entry.

### Description
- Add a `mounted()` hook that calls `this.$refs.searchInput.focus()` to focus the search input element on component mount.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7161b5ad4832484c64331b173eb93)