### PR TITLE
Show remove-column action in table headers when projection mode is off

### DIFF
--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -328,7 +328,6 @@
                         ↓
                       </button>
                       <button
-                        v-if="filteredPaths.length > 0"
                         type="button"
                         @click.stop="removeField(path)"
                         class="p-1.5 rounded-md border border-transparent text-content-tertiary hover:text-valencia-600 hover:bg-valencia-50 hover:border-valencia-200 focus:outline-none focus:ring-2 focus:ring-valencia-500/30"

--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -1209,6 +1209,16 @@ module.exports = app => app.component('models', {
           window.__studioModelsSuppressScrollCheck = true;
         }
       }
+
+      // If projection mode is off, convert current table columns into an explicit
+      // projection first so removing a field both enables projection mode and
+      // hides only the selected field.
+      if (!this.isProjectionMenuSelected) {
+        this.isProjectionMenuSelected = true;
+        this.query[PROJECTION_MODE_QUERY_KEY] = '1';
+        this.filteredPaths = [...this.tableDisplayPaths];
+      }
+
       const index = this.filteredPaths.findIndex(p => p.path === schemaPath.path);
       if (index !== -1) {
         this.filteredPaths.splice(index, 1);


### PR DESCRIPTION
### Motivation

- Users could not hide an individual column from the table unless projection mode was already enabled because the header "x" remove button was only rendered when a projection existed.  The intent is to let users click the header "x" to turn projection mode on and hide that specific field.

### Description

- Always render the remove-column button in table headers by removing the `v-if="filteredPaths.length > 0"` guard in `frontend/src/models/models.html` so the button is visible even when projection mode is off.  
- Update `removeField()` in `frontend/src/models/models.js` to, when projection mode is off, enable projection mode, set `query[PROJECTION_MODE_QUERY_KEY] = '1'`, seed `filteredPaths` from the current `tableDisplayPaths`, then remove the selected field and persist the projection via the existing `syncProjectionFromPaths()` / `updateProjectionQuery()` flow.  
- Preserve existing scroll-restoration logic for table view when toggling projection and updating the query.

### Testing

- Ran `npm run lint` in the project and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71f3052508324927c8e62a99d831b)