### PR TITLE
Restrict Express /api to localhost when no API key configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For local dev, if your app runs on `localhost:3000`, Studio will be on `localhos
 
 By default, Mongoose Studio does **not** provide any authentication or authorization.
 You can use Mongoose Studio for free for local development, but we recommend [Mongoose Studio Pro](https://studio.mongoosejs.io/#pricing) for when you want to go into production.
+When you omit an API key, Mongoose Studio only accepts localhost connections by default.
 
 First, `npm install @mongoosejs/studio`.
 
@@ -41,6 +42,14 @@ opts.googleGeminiAPIKey = process.env.GOOGLE_GEMINI_API_KEY;
 
 // Mount Mongoose Studio on '/studio'
 app.use('/studio', await studio('/studio/api', mongoose, opts));
+```
+
+Without an API key, you can allow access from additional IP addresses with `bindIp`, similar to MongoDB's `bindIp` option. `bindIp` may be a comma-separated string or an array of exact IP addresses. Set `bindIp` to `null` to allow unauthenticated connections from anywhere.
+
+```javascript
+app.use('/studio', await studio('/studio/api', mongoose, {
+  bindIp: '127.0.0.1,192.168.0.10'
+}));
 ```
 
 ### Next.js

--- a/backend/helpers/isBindIPConnection.js
+++ b/backend/helpers/isBindIPConnection.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function isBindIPConnection(req, bindIp) {
+  if (bindIp == null) {
+    return true;
+  }
+  return bindIp.includes(req.ip || '');
+};

--- a/backend/helpers/isLocalhostConnection.js
+++ b/backend/helpers/isLocalhostConnection.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function isLocalhostConnection(req) {
+  const remoteAddress = req.ip || '';
+  return remoteAddress === '127.0.0.1' ||
+    remoteAddress === '::1' ||
+    remoteAddress === '::ffff:127.0.0.1';
+};

--- a/backend/helpers/normalizeBindIPOption.js
+++ b/backend/helpers/normalizeBindIPOption.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function normalizeBindIPOption(bindIp) {
+  if (bindIp === null) {
+    return null;
+  }
+  if (bindIp === undefined) {
+    return ['localhost'];
+  }
+
+  const bindIps = Array.isArray(bindIp) ? bindIp : `${bindIp}`.split(',');
+  return bindIps.
+    flatMap(bindIp => `${bindIp}`.split(',')).
+    map(bindIp => bindIp.trim()).
+    filter(bindIp => bindIp.length > 0);
+};

--- a/express.js
+++ b/express.js
@@ -6,6 +6,14 @@ const frontend = require('./frontend');
 const { toRoute, objectRouter } = require('extrovert');
 const { defaultMothershipURL } = require('./constants');
 
+
+function isLocalhostConnection(req) {
+  const remoteAddress = req.socket?.remoteAddress || req.ip || '';
+  return remoteAddress === '127.0.0.1' ||
+    remoteAddress === '::1' ||
+    remoteAddress === '::ffff:127.0.0.1';
+}
+
 module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) {
   const router = express.Router();
   options = options ? { changeStream: true, ...options } : { changeStream: true };
@@ -39,6 +47,9 @@ module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) 
   router.use(
     '/api',
     function authorize(req, res, next) {
+      if (!workspace && !isLocalhostConnection(req)) {
+        return res.status(403).json({ message: 'Mongoose Studio without an API key only accepts localhost connections' });
+      }
       if (!workspace) {
         next();
         return;

--- a/express.js
+++ b/express.js
@@ -3,20 +3,17 @@
 const Backend = require('./backend');
 const express = require('express');
 const frontend = require('./frontend');
+const isBindIPConnection = require('./backend/helpers/isBindIPConnection');
+const isLocalhostConnection = require('./backend/helpers/isLocalhostConnection');
+const normalizeBindIPOption = require('./backend/helpers/normalizeBindIPOption');
 const { toRoute, objectRouter } = require('extrovert');
 const { defaultMothershipURL } = require('./constants');
-
-
-function isLocalhostConnection(req) {
-  const remoteAddress = req.socket?.remoteAddress || req.ip || '';
-  return remoteAddress === '127.0.0.1' ||
-    remoteAddress === '::1' ||
-    remoteAddress === '::ffff:127.0.0.1';
-}
 
 module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) {
   const router = express.Router();
   options = options ? { changeStream: true, ...options } : { changeStream: true };
+  const hasBindIpOption = Object.prototype.hasOwnProperty.call(options, 'bindIp');
+  const bindIp = normalizeBindIPOption(options.bindIp);
 
   const mothershipUrl = options._mothershipUrl || defaultMothershipURL;
   let workspace = null;
@@ -40,6 +37,17 @@ module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) 
       .then(res => res.json()));
   }
 
+  if (!workspace && bindIp !== null) {
+    router.use((req, res, next) => {
+      const allowed = hasBindIpOption ? isBindIPConnection(req, bindIp) : isLocalhostConnection(req);
+      if (!allowed) {
+        return res.status(403).json({ message: 'Mongoose Studio without an API key only accepts localhost or configured bindIp connections' });
+      }
+
+      next();
+    });
+  }
+
   apiUrl = apiUrl || 'api';
   const backend = Backend(conn, options.studioConnection, options);
   delete backend.services;
@@ -47,9 +55,6 @@ module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) 
   router.use(
     '/api',
     function authorize(req, res, next) {
-      if (!workspace && !isLocalhostConnection(req)) {
-        return res.status(403).json({ message: 'Mongoose Studio without an API key only accepts localhost connections' });
-      }
       if (!workspace) {
         next();
         return;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module '@mongoosejs/studio' {
   const express: (
     path: string,
     connOrMongoose?: Connection | Mongoose,
-    options?: { apiKey?: string }
+    options?: { apiKey?: string; bindIp?: string | string[] | null }
   ) => RequestHandler;
 
   const studio: {

--- a/local.js
+++ b/local.js
@@ -28,7 +28,7 @@ async function run() {
       __build: true,
       __watch: process.env.WATCH,
       _mothershipUrl: 'http://localhost:7777/.netlify/functions',
-      apiKey: 'TACO',
+      //apiKey: 'TACO',
       openAIAPIKey: process.env.OPENAI_API_KEY,
       googleGeminiAPIKey: process.env.GEMINI_API_KEY
     })

--- a/local.js
+++ b/local.js
@@ -28,7 +28,7 @@ async function run() {
       __build: true,
       __watch: process.env.WATCH,
       _mothershipUrl: 'http://localhost:7777/.netlify/functions',
-      //apiKey: 'TACO',
+      apiKey: 'TACO',
       openAIAPIKey: process.env.OPENAI_API_KEY,
       googleGeminiAPIKey: process.env.GEMINI_API_KEY
     })

--- a/test/helpers.isBindIPConnection.test.js
+++ b/test/helpers.isBindIPConnection.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('assert');
+const isBindIPConnection = require('../backend/helpers/isBindIPConnection');
+
+describe('isBindIPConnection', function() {
+  it('allows any connection when bindIp is null', function() {
+    assert.ok(isBindIPConnection({ ip: '203.0.113.10' }, null));
+  });
+
+  it('matches req.ip exactly', function() {
+    const bindIp = ['127.0.0.1', '192.168.0.10'];
+
+    assert.ok(isBindIPConnection({ ip: '127.0.0.1' }, bindIp));
+    assert.ok(isBindIPConnection({ ip: '192.168.0.10' }, bindIp));
+    assert.ok(!isBindIPConnection({ ip: '::ffff:127.0.0.1' }, bindIp));
+    assert.ok(!isBindIPConnection({ ip: '10.0.0.2' }, bindIp));
+  });
+
+  it('does not treat 0.0.0.0 as special', function() {
+    assert.ok(!isBindIPConnection({ ip: '203.0.113.10' }, ['0.0.0.0']));
+  });
+});

--- a/test/helpers.isLocalhostConnection.test.js
+++ b/test/helpers.isLocalhostConnection.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const assert = require('assert');
+const isLocalhostConnection = require('../backend/helpers/isLocalhostConnection');
+
+describe('isLocalhostConnection', function() {
+  it('allows localhost IP addresses', function() {
+    assert.ok(isLocalhostConnection({ ip: '127.0.0.1' }));
+    assert.ok(isLocalhostConnection({ ip: '::1' }));
+    assert.ok(isLocalhostConnection({ ip: '::ffff:127.0.0.1' }));
+  });
+
+  it('rejects non-localhost IP addresses', function() {
+    assert.ok(!isLocalhostConnection({ ip: '192.168.0.5' }));
+    assert.ok(!isLocalhostConnection({}));
+  });
+});

--- a/test/helpers.normalizeBindIPOption.test.js
+++ b/test/helpers.normalizeBindIPOption.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('assert');
+const normalizeBindIPOption = require('../backend/helpers/normalizeBindIPOption');
+
+describe('normalizeBindIPOption', function() {
+  it('defaults to localhost', function() {
+    assert.deepStrictEqual(normalizeBindIPOption(undefined), ['localhost']);
+  });
+
+  it('preserves null', function() {
+    assert.strictEqual(normalizeBindIPOption(null), null);
+  });
+
+  it('splits comma-separated strings', function() {
+    assert.deepStrictEqual(normalizeBindIPOption('127.0.0.1, 192.168.0.10'), ['127.0.0.1', '192.168.0.10']);
+  });
+
+  it('supports arrays and trims values', function() {
+    assert.deepStrictEqual(normalizeBindIPOption(['::1', ' 10.0.0.4 ']), ['::1', '10.0.0.4']);
+  });
+
+  it('filters empty values', function() {
+    assert.deepStrictEqual(normalizeBindIPOption('127.0.0.1,, '), ['127.0.0.1']);
+  });
+});


### PR DESCRIPTION
### Motivation
- Default to localhost-only access for the Express `/api` when no Mongoose Studio API key/workspace is configured to avoid exposing the local dev server.

### Description
- Added `isLocalhostConnection(req)` and updated the `/api` authorization middleware in `express.js` to respond `403` with a clarifying message when no `workspace` (API key) is present and the request is not from localhost, preserving the existing keyed workspace flow.

### Testing
- Ran `npx eslint express.js` which passed, and `npm test` which failed due to the environment lacking a MongoDB instance at `127.0.0.1:27017`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5167f36bc832497fd44759d837479)