### PR TITLE
Add ObjectId display mode dropdown and renderer in document property view

### DIFF
--- a/frontend/src/detail-objectid/detail-objectid.html
+++ b/frontend/src/detail-objectid/detail-objectid.html
@@ -1,0 +1,1 @@
+<pre class="w-full whitespace-pre-wrap break-words font-mono text-sm text-content-secondary m-0">{{displayValue}}</pre>

--- a/frontend/src/detail-objectid/detail-objectid.js
+++ b/frontend/src/detail-objectid/detail-objectid.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const template = require('./detail-objectid.html');
+const ObjectId = require('mongoose/lib/mongoose').ObjectId;
 
 module.exports = app => app.component('detail-objectid', {
   template,
@@ -37,11 +38,7 @@ module.exports = app => app.component('detail-objectid', {
     },
     objectIdDate() {
       const hex = this.hexValue;
-      if (!/^[0-9a-fA-F]{24}$/.test(hex || '')) {
-        return null;
-      }
-      const seconds = parseInt(hex.slice(0, 8), 16);
-      return new Date(seconds * 1000);
+      return new ObjectId(hex).getTimestamp();
     },
     displayValue() {
       if (this.value == null) {
@@ -50,7 +47,7 @@ module.exports = app => app.component('detail-objectid', {
 
       const hex = this.hexValue;
       if (this.format === 'object_call') {
-        return `Object("${hex}")`;
+        return `ObjectId('${hex}')`;
       }
       if (this.format === 'unix_seconds') {
         if (!this.objectIdDate) {

--- a/frontend/src/detail-objectid/detail-objectid.js
+++ b/frontend/src/detail-objectid/detail-objectid.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const template = require('./detail-objectid.html');
+
+module.exports = app => app.component('detail-objectid', {
+  template,
+  props: ['value', 'viewMode'],
+  emits: ['updated'],
+  watch: {
+    displayValue: {
+      immediate: true,
+      handler(val) {
+        this.$emit('updated', val);
+      }
+    }
+  },
+  computed: {
+    format() {
+      return this.viewMode || 'hex';
+    },
+    hexValue() {
+      if (this.value == null) {
+        return null;
+      }
+      if (typeof this.value === 'string') {
+        return this.value;
+      }
+      if (typeof this.value === 'object') {
+        if (typeof this.value.toHexString === 'function') {
+          return this.value.toHexString();
+        }
+        if (typeof this.value.$oid === 'string') {
+          return this.value.$oid;
+        }
+      }
+      return String(this.value);
+    },
+    objectIdDate() {
+      const hex = this.hexValue;
+      if (!/^[0-9a-fA-F]{24}$/.test(hex || '')) {
+        return null;
+      }
+      const seconds = parseInt(hex.slice(0, 8), 16);
+      return new Date(seconds * 1000);
+    },
+    displayValue() {
+      if (this.value == null) {
+        return String(this.value);
+      }
+
+      const hex = this.hexValue;
+      if (this.format === 'object_call') {
+        return `Object("${hex}")`;
+      }
+      if (this.format === 'unix_seconds') {
+        if (!this.objectIdDate) {
+          return 'Invalid ObjectId';
+        }
+        return String(Math.floor(this.objectIdDate.getTime() / 1000));
+      }
+      if (this.format === 'date') {
+        if (!this.objectIdDate) {
+          return 'Invalid ObjectId';
+        }
+        return this.objectIdDate.toISOString();
+      }
+      return hex;
+    }
+  }
+});

--- a/frontend/src/document-details/document-property/document-property.html
+++ b/frontend/src/document-details/document-property/document-property.html
@@ -20,7 +20,7 @@
       <span class="ml-2 text-sm text-content-tertiary">({{(path.instance || 'unknown').toLowerCase()}})</span>
       <div v-if="isGeoJsonGeometry" class="ml-3 inline-flex items-center gap-2">
         <div class="inline-flex items-center rounded-full bg-gray-200 p-0.5 text-xs font-semibold">
-          <button
+      <button
             type="button"
             class="rounded-full px-2.5 py-0.5 transition"
             :class="detailViewMode === 'text' ? 'bg-blue-600 text-white shadow' : 'text-content-secondary hover:text-content'"
@@ -76,6 +76,11 @@
         :path="path"
         @update:viewMode="dateViewMode = $event"
       ></date-view-mode-picker>
+      <objectid-view-mode-picker
+        v-if="isObjectIdPath"
+        :viewMode="objectIdViewMode"
+        @update:viewMode="objectIdViewMode = $event"
+      ></objectid-view-mode-picker>
       <button
         type="button"
         class="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-800 px-2 py-1 rounded-md border border-transparent hover:border-edge-strong bg-surface"
@@ -202,7 +207,7 @@
         <component
           :is="getComponentForPath(path)"
           :value="rawValue"
-          :viewMode="isDatePath ? dateViewMode : detailViewMode"
+          :viewMode="isDatePath ? dateViewMode : (isObjectIdPath ? objectIdViewMode : detailViewMode)"
           @updated="renderedValue = $event"></component>
         <button
           @click="toggleValueExpansion"
@@ -219,7 +224,7 @@
         <component
           :is="getComponentForPath(path)"
           :value="rawValue"
-          :viewMode="isDatePath ? dateViewMode : detailViewMode"
+          :viewMode="isDatePath ? dateViewMode : (isObjectIdPath ? objectIdViewMode : detailViewMode)"
           @updated="renderedValue = $event"></component>
       </div>
     </div>

--- a/frontend/src/document-details/document-property/document-property.js
+++ b/frontend/src/document-details/document-property/document-property.js
@@ -18,6 +18,7 @@ module.exports = app => app.component('document-property', {
     return {
       dateType: 'picker', // picker, iso
       dateViewMode: 'utc_iso',
+      objectIdViewMode: 'hex',
       renderedValue: UNSET,
       isCollapsed: false, // Start uncollapsed by default
       isValueExpanded: false, // Track if the value is expanded
@@ -37,6 +38,9 @@ module.exports = app => app.component('document-property', {
   computed: {
     isDatePath() {
       return this.path?.instance === 'Date';
+    },
+    isObjectIdPath() {
+      return this.path?.instance === 'ObjectID' || this.path?.instance === 'ObjectId';
     },
     rawValue() {
       return this.getValueForPath(this.path.path);
@@ -176,6 +180,9 @@ module.exports = app => app.component('document-property', {
       }
       if (schemaPath.instance === 'Date') {
         return 'detail-date';
+      }
+      if (schemaPath.instance === 'ObjectID' || schemaPath.instance === 'ObjectId') {
+        return 'detail-objectid';
       }
       return 'detail-default';
     },

--- a/frontend/src/document-details/objectid-view-mode-picker/objectid-view-mode-picker.html
+++ b/frontend/src/document-details/objectid-view-mode-picker/objectid-view-mode-picker.html
@@ -1,0 +1,12 @@
+<div class="flex items-center gap-2" @click.stop>
+  <select
+    :value="format"
+    @input="onFormatChange($event.target.value)"
+    class="text-xs border border-edge rounded-md bg-surface px-2 py-1"
+  >
+    <option value="hex">Hex string</option>
+    <option value="object_call">Object(&quot;...&quot;)</option>
+    <option value="unix_seconds">Unix timestamp</option>
+    <option value="date">Date</option>
+  </select>
+</div>

--- a/frontend/src/document-details/objectid-view-mode-picker/objectid-view-mode-picker.html
+++ b/frontend/src/document-details/objectid-view-mode-picker/objectid-view-mode-picker.html
@@ -5,7 +5,7 @@
     class="text-xs border border-edge rounded-md bg-surface px-2 py-1"
   >
     <option value="hex">Hex string</option>
-    <option value="object_call">Object(&quot;...&quot;)</option>
+    <option value="object_call">ObjectId('...')</option>
     <option value="unix_seconds">Unix timestamp</option>
     <option value="date">Date</option>
   </select>

--- a/frontend/src/document-details/objectid-view-mode-picker/objectid-view-mode-picker.js
+++ b/frontend/src/document-details/objectid-view-mode-picker/objectid-view-mode-picker.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const template = require('./objectid-view-mode-picker.html');
+
+module.exports = app => app.component('objectid-view-mode-picker', {
+  template,
+  props: ['viewMode'],
+  emits: ['update:viewMode'],
+  computed: {
+    format() {
+      return this.viewMode || 'hex';
+    }
+  },
+  methods: {
+    onFormatChange(newFormat) {
+      this.$emit('update:viewMode', newFormat);
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide the same flexible display modes for `ObjectId` fields that dates already have so users can view ObjectIds as hex, wrapped `Object("...")`, unix timestamp, or ISO date.

### Description
- Added a new view-mode picker component `frontend/src/document-details/objectid-view-mode-picker/*` that exposes formats: `hex`, `object_call`, `unix_seconds`, and `date` and emits `update:viewMode` when changed.
- Added a new renderer `frontend/src/detail-objectid/*` that normalizes ObjectId input (supports raw string, objects with `toHexString()` or `$oid`) and renders the selected format, deriving the timestamp/date from the ObjectId prefix when applicable.
- Updated `frontend/src/document-details/document-property/document-property.js` and its template to track `objectIdViewMode`, detect `ObjectID`/`ObjectId` schema paths via `isObjectIdPath`, route ObjectId fields to the new `detail-objectid` component, show the ObjectId picker in the field header, and pass the selected view mode into both expanded and regular render paths.

### Testing
- Ran `npm run lint`, which completed successfully; existing unrelated lint warnings remain in other files and were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51cbb7a14832492daa75c48f84e00)