### PR TITLE
Add Drop Collection menu action with guarded confirmation

### DIFF
--- a/backend/actions/Model/dropCollection.js
+++ b/backend/actions/Model/dropCollection.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Archetype = require('archetype');
+const authorize = require('../../authorize');
+
+const DropCollectionParams = new Archetype({
+  model: {
+    $type: 'string',
+    $required: true
+  },
+  roles: {
+    $type: ['string']
+  }
+}).compile('DropCollectionParams');
+
+module.exports = ({ db }) => async function dropCollection(params) {
+  const { model, roles } = new DropCollectionParams(params);
+
+  await authorize('Model.dropCollection', roles);
+
+  const Model = db.models[model];
+  if (Model == null) {
+    throw new Error(`Model ${model} not found`);
+  }
+
+  await Model.collection.drop();
+
+  return { ok: true };
+};

--- a/backend/actions/Model/index.js
+++ b/backend/actions/Model/index.js
@@ -5,6 +5,7 @@ exports.createChatMessage = require('./createChatMessage');
 exports.createDocument = require('./createDocument');
 exports.deleteDocument = require('./deleteDocument');
 exports.deleteDocuments = require('./deleteDocuments');
+exports.dropCollection = require('./dropCollection');
 exports.dropIndex = require('./dropIndex');
 exports.executeDocumentScript = require('./executeDocumentScript');
 exports.exportQueryResults = require('./exportQueryResults');

--- a/backend/authorize.js
+++ b/backend/authorize.js
@@ -17,6 +17,7 @@ const actionsToRequiredRoles = {
   'Model.updateDocument': ['owner', 'admin', 'member'],
   'Model.deleteDocument': ['owner', 'admin', 'member'],
   'Model.deleteDocuments': ['owner', 'admin', 'member'],
+  'Model.dropCollection': ['owner', 'admin'],
   'Model.dropIndex': ['owner', 'admin'],
   'Model.executeDocumentScript': ['owner', 'admin', 'member'],
   'Model.exportQueryResults': ['owner', 'admin', 'member', 'readonly'],

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -163,6 +163,9 @@ if (window.MONGOOSE_STUDIO_CONFIG.isLambda) {
     dropIndex: function dropIndex(params) {
       return client.post('', { action: 'Model.dropIndex', ...params }).then(res => res.data);
     },
+    dropCollection: function dropCollection(params) {
+      return client.post('', { action: 'Model.dropCollection', ...params }).then(res => res.data);
+    },
     listModels: function listModels() {
       return client.post('', { action: 'Model.listModels' }).then(res => res.data);
     },

--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -191,6 +191,13 @@
                   Find oldest document
                 </button>
                 <button
+                  @click="openDropCollectionModal"
+                  type="button"
+                  class="block w-full px-4 py-2 text-left text-sm text-red-700 hover:bg-red-50"
+                >
+                  Drop Collection
+                </button>
+                <button
                   @click="toggleRowNumbers()"
                   type="button"
                   class="block w-full px-4 py-2 text-left text-sm text-content-secondary hover:bg-muted"
@@ -604,6 +611,37 @@
           Confirm
         </async-button>
         <button @click="shouldShowDeleteMultipleModal = false;" class="rounded bg-gray-400 px-2 py-2 text-sm font-semibold text-white shadow-sm hover:bg-page0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500">
+          Cancel
+        </button>
+      </div>
+    </template>
+  </modal>
+  <modal v-if="shouldShowDropCollectionModal">
+    <template v-slot:body>
+      <div class="modal-exit" @click="shouldShowDropCollectionModal = false">&times;</div>
+      <h2 class="text-xl font-bold mb-3">Are you sure?</h2>
+      <p class="text-content-secondary mb-3">
+        This will permanently drop the <span class="font-semibold">{{ currentModel }}</span> collection and all its documents.
+      </p>
+      <div v-if="requiresDropCollectionNameConfirmation()" class="rounded border border-red-300 bg-red-50 px-3 py-2 mb-4">
+        <p class="text-sm font-semibold text-red-700">Danger zone</p>
+        <p class="text-sm text-red-700 mb-2">Type <span class="font-mono font-semibold">{{ currentModel }}</span> to confirm.</p>
+        <input
+          v-model="dropCollectionConfirmName"
+          type="text"
+          :placeholder="currentModel"
+          class="w-full rounded border border-red-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-red-200"
+        />
+      </div>
+      <div class="flex gap-4">
+        <async-button
+          @click="dropCollection"
+          :disabled="requiresDropCollectionNameConfirmation() && dropCollectionConfirmName !== currentModel"
+          class="rounded bg-red-600 px-2 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Drop Collection
+        </async-button>
+        <button @click="shouldShowDropCollectionModal = false" class="rounded bg-gray-400 px-2 py-2 text-sm font-semibold text-white shadow-sm hover:bg-page0">
           Cancel
         </button>
       </div>

--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -168,6 +168,8 @@ module.exports = app => app.component('models', {
     showAddFieldDropdown: false,
     shouldShowIndexModal: false,
     shouldShowCollectionInfoModal: false,
+    shouldShowDropCollectionModal: false,
+    dropCollectionConfirmName: '',
     shouldShowUpdateMultipleModal: false,
     shouldShowDeleteMultipleModal: false,
     shouldExport: {},
@@ -923,6 +925,30 @@ module.exports = app => app.component('models', {
       const { info } = await api.Model.getCollectionInfo({ model: this.currentModel });
       this.collectionInfo = info;
     },
+    openDropCollectionModal() {
+      this.closeActionsMenu();
+      this.dropCollectionConfirmName = '';
+      this.shouldShowDropCollectionModal = true;
+    },
+    requiresDropCollectionNameConfirmation() {
+      const nodeEnv = window?.state?.nodeEnv;
+      return nodeEnv !== 'local';
+    },
+    async dropCollection() {
+      if (this.requiresDropCollectionNameConfirmation() && this.dropCollectionConfirmName !== this.currentModel) {
+        this.$toast.error('Please type the collection name exactly to confirm.');
+        return;
+      }
+
+      await api.Model.dropCollection({ model: this.currentModel });
+      this.shouldShowDropCollectionModal = false;
+      this.dropCollectionConfirmName = '';
+      this.documents = [];
+      this.numDocuments = 0;
+      this.selectedDocuments = [];
+      this.$toast.success(`Collection ${this.currentModel} dropped.`);
+      await this.getDocuments();
+    },
     async findOldestDocument() {
       this.closeActionsMenu();
       const { docs } = await api.Model.getDocuments({
@@ -1058,8 +1084,8 @@ module.exports = app => app.component('models', {
                 const projectionPaths = this.normalizeProjectionPathsForDisplay(routeProjectionInput);
                 const fromProjectionInput = Array.isArray(projectionPaths) ?
                   projectionPaths
-                  .map(path => this.schemaPaths.find(p => p.path === path))
-                  .filter(Boolean) :
+                    .map(path => this.schemaPaths.find(p => p.path === path))
+                    .filter(Boolean) :
                   [];
                 this.filteredPaths = fromProjectionInput;
               } else {


### PR DESCRIPTION
### Motivation
- Provide a safe, user-facing way to permanently drop a model collection from the UI via the models 3-dot menu. 
- Require a clear confirmation step to avoid accidental destructive operations, and make typed confirmation mandatory except in a `local` environment.

### Description
- Added a backend action `Model.dropCollection` at `backend/actions/Model/dropCollection.js` that validates params, enforces authorization, and drops the target collection via `Model.collection.drop()`.
- Wired the action into the server action registry at `backend/actions/Model/index.js` and granted permission for `owner`/`admin` in `backend/authorize.js` under the `Model.dropCollection` key.
- Added a frontend API wrapper `api.Model.dropCollection()` in `frontend/src/api.js` to call the new backend action.
- Added a red `Drop Collection` entry to the models 3-dot actions menu in `frontend/src/models/models.html` and a confirmation modal that always asks "Are you sure?".
- Implemented UI state and behavior in `frontend/src/models/models.js`, including `shouldShowDropCollectionModal`, `dropCollectionConfirmName`, `openDropCollectionModal()`, `requiresDropCollectionNameConfirmation()` (uses `window.state.nodeEnv`), and `dropCollection()` which enforces typed confirmation on non-`local` envs, calls the API, refreshes documents/counts, and shows a success toast.

### Testing
- Ran lint with `npm run -s lint` and it completed successfully while reporting two unrelated pre-existing warnings in `frontend/src/models/projection-search/projection-search.js`.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90f24e1608324a2bf3b5db76beeaf)