### PR TITLE
consistently make db a connection not mongoose instance

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,9 @@ const dashboardResultSchema = require('./db/dashboardResultSchema');
 
 module.exports = function backend(db, studioConnection, options) {
   db = db || mongoose.connection;
+  if (db instanceof mongoose.Mongoose) {
+    db = mongoose.connection;
+  }
 
   studioConnection = studioConnection ?? db;
   const Dashboard = studioConnection.model('__Studio_Dashboard', dashboardSchema, 'studio__dashboards');

--- a/backend/index.js
+++ b/backend/index.js
@@ -12,7 +12,7 @@ const dashboardResultSchema = require('./db/dashboardResultSchema');
 module.exports = function backend(db, studioConnection, options) {
   db = db || mongoose.connection;
   if (db instanceof mongoose.Mongoose) {
-    db = mongoose.connection;
+    db = db.connection;
   }
 
   studioConnection = studioConnection ?? db;


### PR DESCRIPTION
Passing in `require('mongoose')` currently causes AI sandbox to crash with `useDb()` is not a function.