### PR TITLE
Multi connection support

### DIFF
--- a/backend/actions/ChatThread/getChatThread.js
+++ b/backend/actions/ChatThread/getChatThread.js
@@ -19,7 +19,7 @@ const GetChatThreadParams = new Archetype({
   }
 }).compile('GetChatThreadParams');
 
-module.exports = ({ db, studioConnection }) => async function getChatThread(params) {
+module.exports = ({ studioConnection }) => async function getChatThread(params) {
   const { chatThreadId, initiatedById, roles, $workspaceId } = new GetChatThreadParams(params);
   const ChatThread = studioConnection.model('__Studio_ChatThread');
   const ChatMessage = studioConnection.model('__Studio_ChatMessage');
@@ -32,7 +32,7 @@ module.exports = ({ db, studioConnection }) => async function getChatThread(para
     throw new Error('Chat thread not found');
   }
   if (initiatedById && chatThread.userId?.toString() !== initiatedById.toString()) {
-    
+
     if (!$workspaceId || chatThread.workspaceId?.toString() !== $workspaceId.toString() || !chatThread.sharingOptions?.sharedWithWorkspace) {
       throw new Error('Not authorized');
     }

--- a/backend/actions/Dashboard/getDashboard.js
+++ b/backend/actions/Dashboard/getDashboard.js
@@ -59,7 +59,7 @@ module.exports = ({ db, studioConnection, options }) => async function getDashbo
           'failed'
         );
       });
-      return { dashboard, dashboardResult, error: { message: error.message } };
+      return { dashboard, dashboardResult, error: { message: error.message, stack: error.stack } };
     } finally {
       try {
         await sandbox.close();

--- a/backend/actions/Dashboard/getDashboard.js
+++ b/backend/actions/Dashboard/getDashboard.js
@@ -39,7 +39,7 @@ module.exports = ({ db, studioConnection, options }) => async function getDashbo
   const dashboard = await Dashboard.findOne({ _id: dashboardId });
   if (evaluate) {
     let result = null;
-    const sandbox = createSandbox({ db });
+    const sandbox = createSandbox({ db }, true);
     const startExec = startDashboardEvaluate(DashboardResult, dashboardId, $workspaceId, userId);
     startExec.catch(() => {}); // Avoid unhandled promise rejections - we will handle this error later.
     try {

--- a/backend/actions/Model/listModels.js
+++ b/backend/actions/Model/listModels.js
@@ -20,8 +20,10 @@ module.exports = ({ db }) => async function listModels(params) {
   const models = Object.keys(db.models).filter(key => !key.startsWith('__Studio_')).sort();
 
   const modelSchemaPaths = {};
+  const modelConnectionNames = [];
   for (const modelName of models) {
     const Model = db.models[modelName];
+    modelConnectionNames.push(Model.$connectionName);
     const schemaPaths = {};
     modelSchemaPaths[modelName] = schemaPaths;
     for (const path of Object.keys(Model.schema.paths)) {
@@ -51,6 +53,7 @@ module.exports = ({ db }) => async function listModels(params) {
 
   return {
     models,
+    modelConnectionNames,
     modelSchemaPaths,
     readyState
   };

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Actions = require('./actions');
+const ModelContainer = require('./modelContainer');
 const { applySpec } = require('extrovert');
 const mongoose = require('mongoose');
 
@@ -15,7 +16,15 @@ module.exports = function backend(db, studioConnection, options) {
     db = db.connection;
   }
 
-  studioConnection = studioConnection ?? db;
+  let isMultiConnection = false;
+  if (Array.isArray(db)) {
+    studioConnection = db[0];
+    db = new ModelContainer(db);
+    isMultiConnection = true;
+  } else {
+    studioConnection = db;
+  }
+
   const Dashboard = studioConnection.model('__Studio_Dashboard', dashboardSchema, 'studio__dashboards');
   const DashboardResult = studioConnection.model('__Studio_DashboardResult', dashboardResultSchema, 'studio__dashboardResults');
   const ChatMessage = studioConnection.model('__Studio_ChatMessage', chatMessageSchema, 'studio__chatMessages');
@@ -23,6 +32,9 @@ module.exports = function backend(db, studioConnection, options) {
 
   let changeStream = null;
   if (options?.changeStream) {
+    if (isMultiConnection) {
+      throw new Error('changeStream is not supported for multi-connection, disable changeStream option');
+    }
     const conn = db.connection ? db.connection : db;
     if (conn.readyState !== mongoose.Connection.STATES.connected) {
       conn._waitForConnect().then(() => {
@@ -31,10 +43,14 @@ module.exports = function backend(db, studioConnection, options) {
     } else {
       changeStream = conn.watch();
     }
-
   }
 
-  const actions = applySpec(Actions, { db, studioConnection, options, changeStream: () => changeStream });
+  const actions = applySpec(Actions, {
+    db,
+    studioConnection,
+    options,
+    changeStream: () => changeStream
+  });
   actions.services = { changeStream: () => changeStream };
   return actions;
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -21,7 +21,7 @@ module.exports = function backend(db, studioConnection, options) {
     studioConnection = db[0].connection;
     db = new ModelContainer(db);
     isMultiConnection = true;
-  } else {
+  } else if (studioConnection == null) {
     studioConnection = db;
   }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,7 +18,7 @@ module.exports = function backend(db, studioConnection, options) {
 
   let isMultiConnection = false;
   if (Array.isArray(db)) {
-    studioConnection = db[0];
+    studioConnection = db[0].connection;
     db = new ModelContainer(db);
     isMultiConnection = true;
   } else {

--- a/backend/modelContainer.js
+++ b/backend/modelContainer.js
@@ -15,4 +15,8 @@ module.exports = class ModelContainer {
       this.models = { ...this.models, ...connectionWithName.connection.models };
     }
   }
-}
+
+  model(modelName) {
+    return this.models[modelName];
+  }
+};

--- a/backend/modelContainer.js
+++ b/backend/modelContainer.js
@@ -1,9 +1,12 @@
 'use strict';
 
 module.exports = class ModelContainer {
-  constructor(connections) {
+  constructor(connectionsWithNames) {
     this.models = {};
-    for (const connection of connections) {
+    for (const { connection, name } of connectionsWithNames) {
+      for (const model of connection.models) {
+        model.$connectionName = name;
+      }
       this.models = { ...this.models, ...connection.models };
     }
   }

--- a/backend/modelContainer.js
+++ b/backend/modelContainer.js
@@ -3,11 +3,16 @@
 module.exports = class ModelContainer {
   constructor(connectionsWithNames) {
     this.models = {};
-    for (const { connection, name } of connectionsWithNames) {
-      for (const model of connection.models) {
-        model.$connectionName = name;
+    let count = 0;
+    for (const connectionWithName of connectionsWithNames) {
+      ++count;
+      if (!connectionWithName.name) {
+        connectionWithName.name = 'Connection ' + count;
       }
-      this.models = { ...this.models, ...connection.models };
+      for (const model of Object.values(connectionWithName.connection.models)) {
+        model.$connectionName = connectionWithName.name;
+      }
+      this.models = { ...this.models, ...connectionWithName.connection.models };
     }
   }
 }

--- a/backend/modelContainer.js
+++ b/backend/modelContainer.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = class ModelContainer {
+  constructor(connections) {
+    this.models = {};
+    for (const connection of connections) {
+      this.models = { ...this.models, ...connection.models };
+    }
+  }
+}

--- a/backend/sandbox/createSandbox.js
+++ b/backend/sandbox/createSandbox.js
@@ -6,22 +6,15 @@ const mongoose = require('mongoose');
 const vm = require('vm');
 const { createScriptDb } = require('./createScriptDb');
 
-module.exports = function createSandbox({ db }) {
+module.exports = function createSandbox({ db }, useRawDB) {
   const logs = [];
-
-  if (db instanceof ModelContainer) {
-    throw new Error('Cannot create sandbox for ModelContainer');
-  }
 
   // db must be a connection, not a Mongoose instance
   if (db.connection && db.connections) {
     db = db.connection;
   }
 
-  const scriptDb = createScriptDb(db);
-  if (!scriptDb.db.Types) {
-    scriptDb.db.Types = mongoose.Types;
-  }
+  const scriptDb = useRawDB ? db : createScriptDb(db);
 
   const sandbox = {
     db: scriptDb.db,
@@ -50,6 +43,10 @@ module.exports = function createSandbox({ db }) {
 
       if (!dryRun) {
         return await vm.runInContext(wrappedScript, this.context);
+      }
+
+      if (db instanceof ModelContainer) {
+        throw new Error('Cannot dry run when using multiple connections');
       }
 
       return await runDryRunScript({

--- a/backend/sandbox/createSandbox.js
+++ b/backend/sandbox/createSandbox.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const ModelContainer = require('../modelContainer');
 const MongooseStudioChartColors = require('../constants/mongooseStudioChartColors');
 const mongoose = require('mongoose');
 const vm = require('vm');
@@ -7,6 +8,10 @@ const { createScriptDb } = require('./createScriptDb');
 
 module.exports = function createSandbox({ db }) {
   const logs = [];
+
+  if (db instanceof ModelContainer) {
+    throw new Error('Cannot create sandbox for ModelContainer');
+  }
 
   // db must be a connection, not a Mongoose instance
   if (db.connection && db.connections) {

--- a/backend/sandbox/createSandbox.js
+++ b/backend/sandbox/createSandbox.js
@@ -17,7 +17,7 @@ module.exports = function createSandbox({ db }, useRawDB) {
   const scriptDb = useRawDB ? db : createScriptDb(db);
 
   const sandbox = {
-    db: scriptDb.db,
+    db: useRawDB ? db : scriptDb.db,
     mongoose,
     console: {},
     ObjectId: mongoose.Types.ObjectId,
@@ -31,7 +31,7 @@ module.exports = function createSandbox({ db }, useRawDB) {
 
   return {
     context: vm.createContext(sandbox),
-    db: scriptDb.db,
+    db: sandbox.db,
     getLogs() {
       return logs.join('\n');
     },
@@ -56,7 +56,7 @@ module.exports = function createSandbox({ db }, useRawDB) {
         wrappedScript
       });
     },
-    close: scriptDb.close
+    close: useRawDB ? (() => { }) : scriptDb.close
   };
 };
 

--- a/backend/sandbox/createScriptDb.js
+++ b/backend/sandbox/createScriptDb.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ModelContainer = require('../modelContainer');
+
 const wrappedCollections = new WeakSet();
 
 const collectionMethodOptionsIndex = new Map([
@@ -28,6 +30,9 @@ const collectionMethodOptionsIndex = new Map([
 ]);
 
 function createScriptDb(db) {
+  if (db instanceof ModelContainer) {
+    throw new Error('Cannot create script db for ModelContainer');
+  }
   const sourceConnection = db;
 
   const scriptConnection = sourceConnection.useDb(sourceConnection.name, { useCache: false });

--- a/express.js
+++ b/express.js
@@ -13,6 +13,7 @@ const jsonParser = express.json();
 
 module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) {
   const router = express.Router();
+  options = options || {};
   const hasBindIpOption = Object.prototype.hasOwnProperty.call(options, 'bindIp');
   const bindIp = normalizeBindIPOption(options.bindIp);
 

--- a/express.js
+++ b/express.js
@@ -13,7 +13,6 @@ const jsonParser = express.json();
 
 module.exports = async function mongooseStudioExpressApp(apiUrl, conn, options) {
   const router = express.Router();
-  options = options ? { changeStream: true, ...options } : { changeStream: true };
   const hasBindIpOption = Object.prototype.hasOwnProperty.call(options, 'bindIp');
   const bindIp = normalizeBindIPOption(options.bindIp);
 

--- a/frontend/src/models/models.html
+++ b/frontend/src/models/models.html
@@ -28,6 +28,12 @@
               :class="model === currentModel ? 'bg-gray-200 font-semibold text-content' : 'hover:bg-muted'">
               <span class="truncate" v-html="highlightMatch(model)"></span>
               <span
+                v-if="getConnectionColor(model)"
+                class="ml-1.5 inline-block h-2 w-2 shrink-0 rounded-full"
+                :style="{ backgroundColor: getConnectionColor(model) }"
+                :title="modelConnections[model]"
+              ></span>
+              <span
                 v-if="modelDocumentCounts && modelDocumentCounts[model] !== undefined && model !== currentModel"
                 class="ml-auto text-xs text-gray-400 bg-muted rounded px-1.5 py-[1px]"
               >
@@ -39,7 +45,52 @@
         <div class="border-b border-edge my-2"></div>
       </div>
       <!-- All Models / Search Results -->
-      <div class="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">{{ modelSearch.trim() ? 'Search Results' : 'All Models' }}</div>
+      <div class="px-2 py-1 flex items-center gap-2">
+        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">{{ modelSearch.trim() ? 'Search Results' : 'All Models' }}</span>
+        <div v-if="connectionNames.length > 0" class="relative ml-auto min-w-0" ref="connectionDropdownContainer" @keyup.esc.prevent="showConnectionDropdown = false">
+          <button
+            type="button"
+            @click="showConnectionDropdown = !showConnectionDropdown"
+            class="flex items-center gap-1.5 max-w-full rounded border border-edge bg-surface px-1.5 py-0.5 text-xs text-content-secondary hover:bg-muted"
+            title="Filter models by connection"
+          >
+            <span
+              v-if="selectedConnection != null"
+              class="inline-block h-2 w-2 shrink-0 rounded-full"
+              :style="{ backgroundColor: connectionColors[selectedConnection] }"
+            ></span>
+            <span class="truncate">{{ selectedConnection != null ? selectedConnection : 'All connections' }}</span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-3 w-3 shrink-0 text-gray-400">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+            </svg>
+          </button>
+          <div
+            v-if="showConnectionDropdown"
+            class="absolute right-0 top-full mt-1 z-50 min-w-[160px] rounded-md border border-edge bg-surface shadow-lg py-1"
+          >
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-muted"
+              :class="selectedConnection == null ? 'font-semibold text-content' : 'text-content-secondary'"
+              @click="selectConnection(null)"
+            >
+              <span class="inline-block h-2 w-2 shrink-0 rounded-full border border-edge-strong"></span>
+              <span class="truncate">All connections</span>
+            </button>
+            <button
+              v-for="name in connectionNames"
+              :key="'conn-' + name"
+              type="button"
+              class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-muted"
+              :class="name === selectedConnection ? 'font-semibold text-content' : 'text-content-secondary'"
+              @click="selectConnection(name)"
+            >
+              <span class="inline-block h-2 w-2 shrink-0 rounded-full" :style="{ backgroundColor: connectionColors[name] }"></span>
+              <span class="truncate">{{ name }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
       <ul role="list">
         <li v-for="model in filteredModels" :key="'all-' + model">
           <router-link
@@ -47,6 +98,12 @@
             class="flex items-center rounded-md py-1.5 px-2 text-sm text-content-secondary"
             :class="model === currentModel ? 'bg-gray-200 font-semibold text-content' : 'hover:bg-muted'">
             <span class="truncate" v-html="highlightMatch(model)"></span>
+            <span
+              v-if="getConnectionColor(model)"
+              class="ml-1.5 inline-block h-2 w-2 shrink-0 rounded-full"
+              :style="{ backgroundColor: getConnectionColor(model) }"
+              :title="modelConnections[model]"
+            ></span>
             <span
               v-if="modelDocumentCounts && modelDocumentCounts[model] !== undefined && model !== currentModel"
               class="ml-auto text-xs text-gray-400 bg-muted rounded px-1.5 py-[1px]"

--- a/frontend/src/models/models.js
+++ b/frontend/src/models/models.js
@@ -21,6 +21,18 @@ const RECENTLY_VIEWED_MODELS_KEY = 'studio:recently-viewed-models';
 const MAX_RECENT_MODELS = 4;
 const FOCUS_AFTER_MODELS_REMOUNT_KEY = '__studioModelsFocusAfterRemount';
 
+// Low saturation palette with contrasting hues for color coding connections.
+const CONNECTION_COLOR_PALETTE = [
+  'hsl(210, 40%, 62%)', // muted blue
+  'hsl(25, 45%, 62%)', // muted orange
+  'hsl(145, 32%, 55%)', // muted green
+  'hsl(335, 38%, 66%)', // muted pink
+  'hsl(270, 32%, 66%)', // muted purple
+  'hsl(180, 32%, 50%)', // muted teal
+  'hsl(50, 42%, 55%)', // muted gold
+  'hsl(0, 42%, 64%)' // muted red
+];
+
 function setModelsRemountFocusIntent(target) {
   if (typeof window === 'undefined') {
     return;
@@ -143,6 +155,9 @@ module.exports = app => app.component('models', {
   props: ['model', 'user', 'roles'],
   data: () => ({
     models: [],
+    modelConnectionNames: [],
+    selectedConnection: null,
+    showConnectionDropdown: false,
     currentModel: null,
     modelDocumentCounts: {},
     documents: [],
@@ -209,6 +224,7 @@ module.exports = app => app.component('models', {
     window.removeEventListener('popstate', this.onPopState, true);
     document.removeEventListener('click', this.onOutsideActionsMenuClick, true);
     document.removeEventListener('click', this.onOutsideAddFieldDropdownClick, true);
+    document.removeEventListener('click', this.onOutsideConnectionDropdownClick, true);
     document.documentElement.removeEventListener('studio-theme-changed', this.onStudioThemeChanged);
     document.removeEventListener('keydown', this.onCtrlP, true);
     this.destroyMap();
@@ -250,8 +266,18 @@ module.exports = app => app.component('models', {
         this.addFieldFilterText = '';
       }
     };
+    this.onOutsideConnectionDropdownClick = event => {
+      if (!this.showConnectionDropdown) {
+        return;
+      }
+      const container = this.$refs.connectionDropdownContainer;
+      if (container && !container.contains(event.target)) {
+        this.showConnectionDropdown = false;
+      }
+    };
     document.addEventListener('click', this.onOutsideActionsMenuClick, true);
     document.addEventListener('click', this.onOutsideAddFieldDropdownClick, true);
+    document.addEventListener('click', this.onOutsideConnectionDropdownClick, true);
     this.onStudioThemeChanged = () => this.updateMapTileLayer();
     document.documentElement.addEventListener('studio-theme-changed', this.onStudioThemeChanged);
     this.onCtrlP = (event) => {
@@ -264,8 +290,9 @@ module.exports = app => app.component('models', {
     this.query = Object.assign({}, this.$route.query);
     // Keep UI mode in sync with the URL on remounts.
     this.isProjectionMenuSelected = this.$route?.query?.[PROJECTION_MODE_QUERY_KEY] === '1';
-    const { models, modelSchemaPaths, readyState } = await api.Model.listModels();
+    const { models, modelConnectionNames, modelSchemaPaths, readyState } = await api.Model.listModels();
     this.models = models;
+    this.modelConnectionNames = modelConnectionNames ?? [];
     this.allSchemaPaths = modelSchemaPaths;
     await this.loadModelCounts();
     if (this.currentModel == null && this.models.length > 0) {
@@ -280,8 +307,9 @@ module.exports = app => app.component('models', {
     } else {
       this._refreshSidebar = setInterval(async() => {
         try {
-          const { models, modelSchemaPaths, readyState } = await api.Model.listModels();
+          const { models, modelConnectionNames, modelSchemaPaths } = await api.Model.listModels();
           this.models = models;
+          this.modelConnectionNames = modelConnectionNames ?? [];
           this.allSchemaPaths = modelSchemaPaths;
           await this.loadModelCounts();
           if (this.currentModel) {
@@ -381,12 +409,35 @@ module.exports = app => app.component('models', {
       }
       return map;
     },
-    filteredModels() {
-      if (!this.modelSearch.trim()) {
+    modelConnections() {
+      const map = {};
+      for (let i = 0; i < this.models.length; i++) {
+        map[this.models[i]] = this.modelConnectionNames?.[i] ?? null;
+      }
+      return map;
+    },
+    connectionNames() {
+      return [...new Set((this.modelConnectionNames ?? []).filter(name => name != null))];
+    },
+    connectionColors() {
+      const colors = {};
+      this.connectionNames.forEach((name, i) => {
+        colors[name] = CONNECTION_COLOR_PALETTE[i % CONNECTION_COLOR_PALETTE.length];
+      });
+      return colors;
+    },
+    connectionFilteredModels() {
+      if (this.selectedConnection == null) {
         return this.models;
       }
+      return this.models.filter(m => this.modelConnections[m] === this.selectedConnection);
+    },
+    filteredModels() {
+      if (!this.modelSearch.trim()) {
+        return this.connectionFilteredModels;
+      }
       const search = this.modelSearch.trim().toLowerCase();
-      return this.models.filter(m => m.toLowerCase().includes(search));
+      return this.connectionFilteredModels.filter(m => m.toLowerCase().includes(search));
     },
     filteredRecentModels() {
       const recent = this.recentlyViewedModels.filter(m => this.models.includes(m));
@@ -461,6 +512,14 @@ module.exports = app => app.component('models', {
     }
   },
   methods: {
+    getConnectionColor(model) {
+      const connectionName = this.modelConnections[model];
+      return connectionName == null ? null : this.connectionColors[connectionName];
+    },
+    selectConnection(name) {
+      this.selectedConnection = name;
+      this.showConnectionDropdown = false;
+    },
     highlightMatch(model) {
       const search = this.modelSearch.trim();
       if (!search) {

--- a/test/Dashboard.getDashboard.error.test.js
+++ b/test/Dashboard.getDashboard.error.test.js
@@ -24,7 +24,6 @@ describe('Dashboard.getDashboard() error handling', function () {
     });
 
     assert.ok(res.dashboard);
-    assert.deepStrictEqual(res.error, { message: 'test error' });
     assert.ok(res.dashboardResult);
     assert.strictEqual(res.dashboardResult.status, 'failed');
     assert.strictEqual(res.dashboardResult.error.message, 'test error');


### PR DESCRIPTION
Currently you're limited to using Mongoose Studio with 1 connection, which doesn't work well if your app uses multiple databases or multiple clusters. With this PR, you can do the following:

```javascript
  const conn1 = await mongoose.createConnection('mongodb://127.0.0.1:27017/studio_test1').asPromise();
  const conn2 = await mongoose.createConnection('mongodb://127.0.0.1:27017/studio_test2').asPromise();

  conn1.model('User', { name: String });
  conn2.model('Taco', { filling: String, spicy: Boolean });

  app.use('/studio', await studio(
    null,
    [
      { connection: conn1, name: 'Conn1' },
      { connection: conn2, name: 'Conn2' },
    ],
    {
      changeStream: false
    })
  );
```

You can use dashboards and you get nice color-coded UI for browsing models from different connections:

<img width="1228" height="590" alt="image" src="https://github.com/user-attachments/assets/492aa6a0-b0bb-450e-a7b4-8dcf4e2c3178" />
